### PR TITLE
fix(agents): close pilot readiness gaps

### DIFF
--- a/.agents/skills/implement-and-review/SKILL.md
+++ b/.agents/skills/implement-and-review/SKILL.md
@@ -50,7 +50,35 @@ failure and `release-monorepo` own release preparation.
 
 ## 3. Scope lock
 
-Before editing, record:
+Before editing, run:
+
+```sh
+git status --short
+git rev-parse HEAD
+```
+
+A clean worktree is the default precondition for an ordinary write task. When
+pre-existing changes exist, record every path and classify whether it is
+related, unrelated, or overlapping. Never automatically remove or overwrite
+pre-existing changes. Continue only with explicit user authorization and
+non-overlapping ownership, or use a clean isolated worktree. An overlapping
+target path blocks the edit until the user authorizes working on the combined
+content or a clean worktree is available.
+
+Prefer an isolated worktree for unrelated pre-existing changes when local Git
+operations are authorized and a safe new path and branch are available. Do not
+delete another worktree, overwrite a branch, prune worktrees, or remove the
+isolated worktree without authorization. Record its path and branch. If safe
+isolation is unsuitable for unrelated changes, stop and report a blocker.
+
+Before treating generated or temporary files as harmless, verify whether Git
+ignores them, who created them, and whether they can affect tests or diffs.
+
+Without a clean or isolated worktree, the task-base-to-current-tree result is a
+combined diff that may contain pre-existing changes. Separate files by their
+initial state. You must not claim agent ownership of the whole combined diff.
+
+Then record:
 
 - the immutable task base SHA from `git rev-parse HEAD`;
 - the initial branch, working tree, and staged state;
@@ -119,12 +147,31 @@ git diff --cached
 git diff --stat "$TASK_BASE_SHA"
 git diff --check "$TASK_BASE_SHA"
 git diff "$TASK_BASE_SHA"
+git ls-files --others --exclude-standard
 ```
 
 The cached commands may be omitted only when nothing is staged. The task base
 commands are the task-base-to-current-working-tree review and remain required
 even when ordinary unstaged or staged diffs are empty. Review the complete task
 diff rather than remembered edits.
+
+Classify each untracked result as task-created, pre-existing, or unexpected.
+Before reading content, inspect the path, type, and size so binary or oversized
+files remain bounded. Read every task-created untracked text file in full and
+review it for correctness, security, tests, documentation, credentials,
+temporary data, and absolute paths. Unexpected untracked files prevent `READY`
+unless they are verified, harmless, explained test output. An unreviewed
+untracked file prevents `READY`; never silently ignore or automatically delete
+one.
+
+Before committing, stage only explicit authorized paths:
+
+```sh
+git add -- <authorized-path-1> <authorized-path-2>
+git diff --cached --stat
+git diff --cached --check
+git diff --cached
+```
 
 After a commit, and after every later Git or remote mutation, also re-read:
 
@@ -136,6 +183,10 @@ git log -1 --oneline
 git diff --stat "$TASK_BASE_SHA"..HEAD
 git diff "$TASK_BASE_SHA"..HEAD
 ```
+
+After a commit, repeat untracked file discovery and the complete
+task-base-to-HEAD review. This verifies both committed additions and any
+unexpected files left outside the commit.
 
 Use the two-dot task-base-to-HEAD diff for the task's tree change. Do not
 substitute a three-dot merge-base diff. If the working tree is still dirty,
@@ -181,6 +232,10 @@ and list each blocker.
 Finish only when:
 
 - the request is implemented and the diff remains in scope;
+- the initial worktree was clean, a clean isolated worktree was used, or the
+  user authorized the recorded non-overlapping/combined ownership boundary;
+- every untracked file is classified and every task-created untracked text file
+  was read in full;
 - no known P0 or in-scope P1 remains;
 - required validation and `git diff --check` pass;
 - no accidental files exist and documentation matches behavior;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,10 +193,20 @@ and repository research:
 
 For user-authorized implementation or modification:
 
+- A clean worktree is the default precondition for an ordinary write task. If
+  pre-existing changes exist, preserve and record every path, then continue
+  only with explicit user authorization and non-overlapping ownership or use a
+  clean isolated worktree. Overlapping target paths block the edit.
 - Record the pre-edit `git rev-parse HEAD` as the immutable task base SHA.
 - Review unstaged and staged changes plus the complete task-base-to-current
   working tree and task-base-to-HEAD diff. A commit must not make the task diff
   disappear from review.
+- Without a clean or isolated worktree, call the result a combined diff,
+  and separate paths by their initial state. You must not claim agent ownership
+  of all changes.
+- Run `git ls-files --others --exclude-standard`; classify every result and
+  read each task-created untracked text file in full. An unexplained or
+  unreviewed untracked file prevents readiness.
 - Resolve every known P0 and every in-scope P1, rerun affected validation, and
   review the complete task diff again after the last repair.
 - Require the applicable `git diff --check` checks to pass and verify there are

--- a/docs/agents/agents-and-skills-architecture.md
+++ b/docs/agents/agents-and-skills-architecture.md
@@ -207,13 +207,15 @@ route.
 
 ```text
 discover Git-tracked repository rules
+  -> require a clean worktree or establish an authorized isolation boundary
   -> classify one primary domain
   -> record task base SHA, initial Git state, scope, and authority
   -> plan
   -> implement
   -> focused validation
+  -> discover and fully review task-created untracked text files
   -> review unstaged/staged and task-base-to-current-tree diff
-  -> review task-base-to-HEAD diff, including after commit
+  -> review task-base-to-HEAD and untracked files again after commit
   -> grade P0/P1/P2
   -> repair in-scope P0/P1
   -> rerun affected validation and complete review (maximum three rounds)
@@ -236,7 +238,19 @@ is not automatically `origin/main`. Complete review includes unstaged and
 staged changes, the task base to the current working tree, and the two-dot task
 base to `HEAD` tree change. After a commit, an empty ordinary `git diff` cannot
 hide the task: the task-base-to-HEAD diff is reviewed again together with fresh
-status, branch, HEAD, and log evidence.
+status, branch, HEAD, log, and untracked-file evidence.
+
+A clean worktree is the ordinary write-task default. Pre-existing changes are
+recorded and preserved, not assumed to be agent work. Unrelated changes favor a
+clean isolated worktree; overlapping targets block editing without explicit
+authorization. If isolation is unavailable, the task-base-to-current-tree view
+is a combined diff and cannot be wholly attributed to the agent. This is a
+conservative ownership boundary, not arbitrary patch attribution.
+
+Untracked discovery uses `git ls-files --others --exclude-standard`. Every
+task-created text file is size-checked and read in full; unexpected or
+unreviewed files prevent readiness. Staging uses explicit authorized paths,
+followed by a complete cached stat, whitespace, and content review.
 
 Completion gates differ by authority. All tasks re-check the request, separate
 fact from inference, report limitations and external operations, and avoid
@@ -245,6 +259,27 @@ does not require build, test, or diff ceremony unless needed for the answer.
 Write tasks record the task base, validate the change, close in-scope P0/P1,
 and review the complete task diff. Discovering a P1 during a read-only task
 does not automatically authorize a repair.
+
+## Real-task Pilot PR gate
+
+```text
+Draft PR
+  -> local validation complete
+  -> autonomous review complete
+  -> repair P0/P1
+  -> push the latest commit
+  -> Ready for review
+  -> wait for remote required checks
+  -> human review of the PR diff
+  -> user decides whether to merge
+```
+
+Local `PASS` is not remote CI `PASS`; name the successful remote workflow or
+check and commit SHA before reporting remote success. `Draft` status is not
+completed remote acceptance. Query checks after the PR becomes Ready for
+review. If check evidence is absent, unavailable, or the repository has no
+verified required-check policy, report `REMOTE CI UNVERIFIED`, not `PASS`.
+Only the user may decide whether to merge; this Pilot never performs the merge.
 
 ## Real-task routing validation
 

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -895,16 +895,35 @@ function validateImplementationSkill(contents, failures) {
 			"implement-and-review must record the task base with git rev-parse HEAD",
 		);
 	}
+	for (const unsafeCommand of ["git clean", "git reset --hard"]) {
+		if (contents.includes(unsafeCommand)) {
+			failures.push(
+				`implement-and-review must not recommend destructive command ${unsafeCommand}`,
+			);
+		}
+	}
 	for (const command of [
 		'git diff --stat "$TASK_BASE_SHA"',
 		'git diff --check "$TASK_BASE_SHA"',
 		'git diff "$TASK_BASE_SHA"',
 		'git diff --stat "$TASK_BASE_SHA"..HEAD',
 		'git diff "$TASK_BASE_SHA"..HEAD',
+		"git ls-files --others --exclude-standard",
+		"git add -- <authorized-path-1> <authorized-path-2>",
+		"git diff --cached --stat",
+		"git diff --cached --check",
+		"git diff --cached",
 	]) {
 		if (!hasExactLine(contents, command)) {
 			failures.push(
 				`implement-and-review is missing required task-base diff command ${command}`,
+			);
+		}
+	}
+	for (const unsafeCommand of ["git add .", "git add -A"]) {
+		if (hasExactLine(contents, unsafeCommand)) {
+			failures.push(
+				`implement-and-review must not allow unbounded staging command ${unsafeCommand}`,
 			);
 		}
 	}
@@ -944,6 +963,16 @@ function validateImplementationSkill(contents, failures) {
 		"`PASS`",
 		"`FAIL`",
 		"`SKIPPED`",
+		"A clean worktree is the default precondition",
+		"pre-existing changes",
+		"Never automatically remove or overwrite",
+		"isolated worktree",
+		"combined diff",
+		"must not claim agent ownership",
+		"Read every task-created untracked text file in full",
+		"Unexpected untracked files prevent `READY`",
+		"untracked file prevents `READY`",
+		"After a commit, repeat untracked file discovery",
 	]) {
 		if (!contents.includes(marker))
 			failures.push(
@@ -995,6 +1024,19 @@ function validateRootDefinitionOfDone(contents, failures) {
 			"AGENTS.md write tasks must require task-base-to-current and task-base-to-HEAD review",
 		);
 	}
+	for (const marker of [
+		"clean worktree",
+		"pre-existing changes",
+		"isolated worktree",
+		"combined diff",
+		"must not claim agent ownership",
+		"git ls-files --others --exclude-standard",
+		"read each task-created untracked text file in full",
+	]) {
+		if (!write.includes(marker)) {
+			failures.push(`AGENTS.md write tasks are missing safety marker ${marker}`);
+		}
+	}
 }
 
 function validateArchitectureDocument(contents, trackedSkills, failures) {
@@ -1028,6 +1070,54 @@ function validateArchitectureDocument(contents, trackedSkills, failures) {
 				`${ARCHITECTURE_DOCUMENT} must document ${skillName} exactly once, found ${count}`,
 			);
 		}
+	}
+	let pilotSection;
+	try {
+		pilotSection = markdownSection(contents, "## Real-task Pilot PR gate").join(
+			"\n",
+		);
+	} catch (error) {
+		failures.push(`${ARCHITECTURE_DOCUMENT} ${error.message}`);
+		return;
+	}
+	const pilotMarkers = [
+		"Draft PR",
+		"local validation complete",
+		"autonomous review complete",
+		"repair P0/P1",
+		"push the latest commit",
+		"Ready for review",
+		"wait for remote required checks",
+		"human review of the PR diff",
+		"user decides whether to merge",
+	];
+	let priorIndex = -1;
+	for (const marker of pilotMarkers) {
+		const markerIndex = pilotSection.indexOf(marker);
+		if (markerIndex < 0 || markerIndex <= priorIndex) {
+			failures.push(
+				`${ARCHITECTURE_DOCUMENT} must document the ordered Pilot PR gate through ${marker}`,
+			);
+			break;
+		}
+		priorIndex = markerIndex;
+	}
+	for (const marker of [
+		"Local `PASS` is not remote CI `PASS`",
+		"`Draft` status is not",
+		"`REMOTE CI UNVERIFIED`",
+		"Only the user may decide whether to merge",
+	]) {
+		if (!pilotSection.includes(marker)) {
+			failures.push(
+				`${ARCHITECTURE_DOCUMENT} is missing Pilot PR evidence marker ${marker}`,
+			);
+		}
+	}
+	if (/\bmay automatically merge\b/i.test(pilotSection)) {
+		failures.push(
+			`${ARCHITECTURE_DOCUMENT} must not allow automatic merge in the Pilot`,
+		);
 	}
 }
 

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -105,8 +105,11 @@ ${routes.join("\n")}
 
 ### Write tasks
 
+- A clean worktree preserves pre-existing changes or uses an isolated worktree.
+- A combined diff must not claim agent ownership.
 - Record the task base with \`git rev-parse HEAD\`.
 - Review the task-base-to-current tree and task-base-to-HEAD diff.
+- Run \`git ls-files --others --exclude-standard\` and read each task-created untracked text file in full.
 `;
 }
 
@@ -123,6 +126,23 @@ Tracked Skill count: \`${EXPECTED_SKILL_ROLES.size}\`.
 | Skill | Contract role |
 | --- | --- |
 ${roles.join("\n")}
+
+## Real-task Pilot PR gate
+
+Draft PR
+local validation complete
+autonomous review complete
+repair P0/P1
+push the latest commit
+Ready for review
+wait for remote required checks
+human review of the PR diff
+user decides whether to merge
+
+Local \`PASS\` is not remote CI \`PASS\`.
+\`Draft\` status is not completed remote acceptance.
+\`REMOTE CI UNVERIFIED\`
+Only the user may decide whether to merge.
 `;
 }
 
@@ -945,6 +965,67 @@ test("implementation lifecycle rejects unsafe discovery and incomplete task-base
 			await auditAgentAndSkillContracts(root),
 			contractCase.failure,
 		);
+	}
+});
+
+test("implementation lifecycle enforces clean-worktree ownership boundaries", async (t) => {
+	const cases = [
+		["A clean worktree is the default precondition", "A dirty worktree is acceptable", /missing required lifecycle marker A clean worktree/],
+		["pre-existing changes", "earlier edits", /missing required lifecycle marker pre-existing changes/],
+		["must not claim agent ownership", "may claim agent ownership", /missing required lifecycle marker must not claim agent ownership/],
+		["isolated worktree", "temporary checkout", /missing required lifecycle marker isolated worktree/],
+		["Never automatically remove or overwrite", "Automatically remove or overwrite", /missing required lifecycle marker Never automatically remove/],
+		["", "\n```sh\ngit clean -fd\n```", /must not recommend destructive command git clean/],
+		["", "\n```sh\ngit reset --hard\n```", /must not recommend destructive command git reset --hard/],
+	];
+	for (const [from, to, failure] of cases) {
+		const root = await createContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			".agents/skills/implement-and-review/SKILL.md",
+			(contents) => (from ? contents.replaceAll(from, to) : `${contents}${to}\n`),
+		);
+		assertFailure(await auditAgentAndSkillContracts(root), failure);
+	}
+});
+
+test("implementation lifecycle fully reviews untracked and staged files", async (t) => {
+	const cases = [
+		["git ls-files --others --exclude-standard", "git status --short", /missing required task-base diff command git ls-files/],
+		["Read every task-created untracked text file in full", "Review every untracked filename", /missing required lifecycle marker Read every task-created/],
+		["untracked file prevents `READY`", "untracked file is acceptable", /missing required lifecycle marker untracked file prevents/],
+		["Unexpected untracked files prevent `READY`", "Unexpected files may be silently ignored", /missing required lifecycle marker Unexpected untracked/],
+		["", "\n```sh\ngit add .\n```", /must not allow unbounded staging command git add \./],
+		["git diff --cached --stat", "git diff --cached --name-only", /missing required task-base diff command git diff --cached --stat/],
+		["After a commit, repeat untracked file discovery", "After a commit, skip untracked discovery", /missing required lifecycle marker After a commit/],
+	];
+	for (const [from, to, failure] of cases) {
+		const root = await createContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			".agents/skills/implement-and-review/SKILL.md",
+			(contents) => (from ? contents.replaceAll(from, to) : `${contents}${to}\n`),
+		);
+		assertFailure(await auditAgentAndSkillContracts(root), failure);
+	}
+});
+
+test("architecture contract enforces the Pilot Draft-to-Ready evidence gate", async (t) => {
+	const cases = [
+		["Ready for review", "Open for discussion", /ordered Pilot PR gate through Ready for review/],
+		["Local `PASS` is not remote CI `PASS`", "Local and remote PASS are equivalent", /missing Pilot PR evidence marker Local/],
+		["`Draft` status is not", "Draft status is", /missing Pilot PR evidence marker `Draft`/],
+		["`REMOTE CI UNVERIFIED`", "`PASS`", /missing Pilot PR evidence marker `REMOTE CI UNVERIFIED`/],
+		["Only the user may decide whether to merge", "The service may automatically merge", /must not allow automatic merge/],
+	];
+	for (const [from, to, failure] of cases) {
+		const root = await createContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			"docs/agents/agents-and-skills-architecture.md",
+			(contents) => contents.replaceAll(from, to),
+		);
+		assertFailure(await auditAgentAndSkillContracts(root), failure);
 	}
 });
 


### PR DESCRIPTION
## What changed

- make a clean worktree the default precondition for ordinary write tasks, with explicit handling for pre-existing, overlapping, and isolated-worktree cases
- require discovery, classification, bounded full-text review, explicit staging, and post-commit re-review of untracked files
- document the real-task Pilot path from Draft PR through Ready, remote check evidence, human diff review, and user-controlled merge
- extend the lightweight repository contract with 19 focused negative cases

## Why

A task-base SHA cannot attribute changes that already existed in a dirty worktree, and ordinary `git diff` does not include untracked file bodies. Those gaps could let an agent over-claim ownership or mark an incompletely reviewed change READY.

## Impact

This changes Agent/Skill governance, architecture documentation, and repository contract tests only. It does not change product runtime code, workflows, dependencies, lockfiles, versions, or Changesets.

## Validation

- `node --check scripts/repository-contract.mjs`
- `node --check scripts/repository-contract.node-test.mjs`
- `node --test scripts/repository-contract.node-test.mjs`
- `pnpm verify:repository-contract`
- `pnpm test:release-scripts`
- `pnpm lint:changed`
- `pnpm build --concurrency=1`
- `pnpm typecheck --concurrency=1`
- `pnpm test:vitest` (643 passed, 2 skipped)
- Skill `quick_validate.py`
- staged and task-base `git diff --check`
