### PR TITLE
fix(ci): make publication SHA guard dependency-free

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags origin main
-          guard="$(node scripts/release/publication.mjs verify-sha \
+          guard="$(node scripts/release/publication-sha-guard.mjs \
             --expected-sha "${EXPECTED_SHA}" \
             --github-sha "${GITHUB_SHA}" \
             --github-ref "${GITHUB_REF}")"
@@ -168,6 +168,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Revalidate current main after Environment approval
+        id: approval-sha-guard
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.preflight-and-package.outputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          guard="$(node scripts/release/publication-sha-guard.mjs \
+            --expected-sha "${EXPECTED_SHA}" \
+            --github-sha "${GITHUB_SHA}" \
+            --github-ref "${GITHUB_REF}")"
+          printf '%s\n' "${guard}" | jq -e '.success == true' >/dev/null
+
       - name: Set up pnpm
         uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
         with:
@@ -187,20 +201,6 @@ jobs:
         with:
           name: ${{ needs.preflight-and-package.outputs.artifact_name }}
           path: .ci-artifacts/publication
-
-      - name: Revalidate current main after Environment approval
-        id: approval-sha-guard
-        shell: bash
-        env:
-          EXPECTED_SHA: ${{ needs.preflight-and-package.outputs.expected_sha }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin main
-          guard="$(node scripts/release/publication.mjs verify-sha \
-            --expected-sha "${EXPECTED_SHA}" \
-            --github-sha "${GITHUB_SHA}" \
-            --github-ref "${GITHUB_REF}")"
-          printf '%s\n' "${guard}" | jq -e '.success == true' >/dev/null
 
       - name: Verify downloaded bytes and exact Workflow facts
         id: artifact-verification

--- a/scripts/release/publication-sha-guard.mjs
+++ b/scripts/release/publication-sha-guard.mjs
@@ -1,0 +1,153 @@
+import { execFile } from "node:child_process";
+import { realpath } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const repositoryRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	"../..",
+);
+
+export class PublicationShaGuardError extends Error {
+	constructor(code, message) {
+		super(message);
+		this.code = code;
+	}
+}
+
+async function resolveCommit(root, revision, code, message) {
+	try {
+		const { stdout } = await execFileAsync(
+			"git",
+			["rev-parse", "--verify", `${revision}^{commit}`],
+			{
+				cwd: root,
+				encoding: "utf8",
+			},
+		);
+		return stdout.trim();
+	} catch {
+		throw new PublicationShaGuardError(code, message);
+	}
+}
+
+export async function verifyPublicationSha({
+	root = repositoryRoot,
+	expectedSha,
+	githubSha,
+	githubRef,
+	resolveCheckoutSha = () =>
+		resolveCommit(
+			root,
+			"HEAD",
+			"CHECKOUT_HEAD_UNAVAILABLE",
+			"Unable to resolve the current checkout HEAD.",
+		),
+	resolveRemoteSha = () =>
+		resolveCommit(
+			root,
+			"refs/remotes/origin/main",
+			"REMOTE_MAIN_UNAVAILABLE",
+			"Unable to resolve the fetched origin/main commit.",
+		),
+} = {}) {
+	if (!/^[0-9a-f]{40}$/.test(expectedSha ?? "")) {
+		throw new PublicationShaGuardError(
+			"INVALID_EXPECTED_SHA",
+			"expected_sha must be a full lowercase 40-character commit SHA.",
+		);
+	}
+	if (githubRef !== "refs/heads/main") {
+		throw new PublicationShaGuardError(
+			"INVALID_PUBLICATION_REF",
+			"Publication must be dispatched from refs/heads/main.",
+		);
+	}
+	if (githubSha !== expectedSha) {
+		throw new PublicationShaGuardError(
+			"DISPATCH_SHA_MISMATCH",
+			"expected_sha does not match the GitHub Actions dispatch commit.",
+		);
+	}
+
+	const checkoutHead = await resolveCheckoutSha();
+	if (checkoutHead !== expectedSha) {
+		throw new PublicationShaGuardError(
+			"CHECKOUT_HEAD_SHA_MISMATCH",
+			"Current checkout HEAD does not match expected_sha.",
+		);
+	}
+
+	const remoteMain = await resolveRemoteSha();
+	if (remoteMain !== expectedSha) {
+		throw new PublicationShaGuardError(
+			"REMOTE_MAIN_SHA_MISMATCH",
+			"Fetched origin/main does not match expected_sha.",
+		);
+	}
+
+	return {
+		success: true,
+		expectedSha,
+		githubSha,
+		githubRef,
+		checkoutHead,
+		remoteMain,
+	};
+}
+
+function parseArguments(argv) {
+	const options = { root: repositoryRoot };
+	const allowedArguments = new Set([
+		"--expected-sha",
+		"--github-sha",
+		"--github-ref",
+		"--root",
+	]);
+	for (let index = 0; index < argv.length; index += 2) {
+		const argument = argv[index];
+		if (!allowedArguments.has(argument) || index + 1 >= argv.length) {
+			throw new PublicationShaGuardError(
+				"INVALID_ARGUMENT",
+				`Unknown or incomplete argument: ${argument ?? "<missing>"}`,
+			);
+		}
+		const value = argv[index + 1];
+		if (argument === "--expected-sha") options.expectedSha = value;
+		else if (argument === "--github-sha") options.githubSha = value;
+		else if (argument === "--github-ref") options.githubRef = value;
+		else options.root = resolve(value);
+	}
+	return options;
+}
+
+function writeJson(result) {
+	process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+	try {
+		writeJson(await verifyPublicationSha(parseArguments(argv)));
+	} catch (error) {
+		const code =
+			error instanceof PublicationShaGuardError
+				? error.code
+				: "PUBLICATION_SHA_GUARD_FAILED";
+		const message =
+			error instanceof Error ? error.message : "Publication SHA guard failed.";
+		writeJson({ success: false, code });
+		process.stderr.write(`${code}: ${message}\n`);
+		process.exitCode = 1;
+	}
+}
+
+if (
+	process.argv[1] &&
+	(await realpath(resolve(process.argv[1]))) ===
+		(await realpath(fileURLToPath(import.meta.url)))
+) {
+	await main();
+}

--- a/scripts/release/publication-sha-guard.node-test.mjs
+++ b/scripts/release/publication-sha-guard.node-test.mjs
@@ -1,0 +1,204 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import {
+	access,
+	cp,
+	mkdir,
+	mkdtemp,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const guardSourcePath = fileURLToPath(
+	new URL("./publication-sha-guard.mjs", import.meta.url),
+);
+
+async function git(root, ...argumentsList) {
+	const { stdout } = await execFileAsync("git", argumentsList, {
+		cwd: root,
+		encoding: "utf8",
+	});
+	return stdout.trim();
+}
+
+async function createCheckout(t) {
+	const fixtureRoot = await mkdtemp(
+		join(tmpdir(), "openapi-to-publication-sha-guard-"),
+	);
+	t.after(() => rm(fixtureRoot, { recursive: true, force: true }));
+	const origin = join(fixtureRoot, "origin.git");
+	const checkout = join(fixtureRoot, "checkout");
+	await mkdir(origin);
+	await git(origin, "init", "--bare", "--quiet");
+	await mkdir(checkout);
+	await git(checkout, "init", "--quiet", "--initial-branch=main");
+	await git(checkout, "config", "user.name", "Publication SHA Guard Test");
+	await git(
+		checkout,
+		"config",
+		"user.email",
+		"publication-sha-guard@example.invalid",
+	);
+	await mkdir(join(checkout, "scripts/release"), { recursive: true });
+	await cp(
+		guardSourcePath,
+		join(checkout, "scripts/release/publication-sha-guard.mjs"),
+	);
+	await writeFile(join(checkout, "fixture.txt"), "fixture\n");
+	await git(checkout, "add", "--", ".");
+	await git(checkout, "commit", "--quiet", "-m", "Create guard fixture");
+	await git(checkout, "remote", "add", "origin", origin);
+	await git(checkout, "push", "--quiet", "--set-upstream", "origin", "main");
+	const sha = await git(checkout, "rev-parse", "HEAD");
+	return { checkout, sha };
+}
+
+async function alternateCommit(checkout, parentSha) {
+	const tree = await git(checkout, "rev-parse", `${parentSha}^{tree}`);
+	return git(
+		checkout,
+		"commit-tree",
+		tree,
+		"-p",
+		parentSha,
+		"-m",
+		"Alternate commit",
+	);
+}
+
+async function runGuard(
+	checkout,
+	{ expectedSha, githubSha, githubRef = "refs/heads/main" },
+) {
+	const argumentsList = [
+		join(checkout, "scripts/release/publication-sha-guard.mjs"),
+		"--expected-sha",
+		expectedSha,
+		"--github-sha",
+		githubSha,
+		"--github-ref",
+		githubRef,
+	];
+	try {
+		const { stdout, stderr } = await execFileAsync(
+			process.execPath,
+			argumentsList,
+			{
+				cwd: checkout,
+				encoding: "utf8",
+			},
+		);
+		return { code: 0, stdout, stderr };
+	} catch (error) {
+		return {
+			code: error.code,
+			stdout: error.stdout,
+			stderr: error.stderr,
+		};
+	}
+}
+
+function assertGuardFailure(result, expectedCode) {
+	assert.notEqual(result.code, 0);
+	assert.deepEqual(JSON.parse(result.stdout), {
+		success: false,
+		code: expectedCode,
+	});
+	assert.match(result.stderr, new RegExp(`^${expectedCode}:`));
+}
+
+test("SHA guard succeeds in a temporary checkout without node_modules", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	await assert.rejects(access(join(checkout, "node_modules")), {
+		code: "ENOENT",
+	});
+
+	const result = await runGuard(checkout, {
+		expectedSha: sha,
+		githubSha: sha,
+	});
+
+	assert.equal(result.code, 0);
+	assert.equal(result.stderr, "");
+	assert.deepEqual(JSON.parse(result.stdout), {
+		success: true,
+		expectedSha: sha,
+		githubSha: sha,
+		githubRef: "refs/heads/main",
+		checkoutHead: sha,
+		remoteMain: sha,
+	});
+	await assert.rejects(access(join(checkout, "node_modules")), {
+		code: "ENOENT",
+	});
+});
+
+test("SHA guard rejects a GitHub dispatch SHA mismatch", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	const result = await runGuard(checkout, {
+		expectedSha: sha,
+		githubSha: "b".repeat(40),
+	});
+	assertGuardFailure(result, "DISPATCH_SHA_MISMATCH");
+});
+
+test("SHA guard rejects origin/main drift", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	const alternateSha = await alternateCommit(checkout, sha);
+	await git(
+		checkout,
+		"update-ref",
+		"refs/remotes/origin/main",
+		alternateSha,
+	);
+
+	const result = await runGuard(checkout, {
+		expectedSha: sha,
+		githubSha: sha,
+	});
+	assertGuardFailure(result, "REMOTE_MAIN_SHA_MISMATCH");
+});
+
+test("SHA guard rejects a mismatched checkout HEAD", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	const alternateSha = await alternateCommit(checkout, sha);
+	await git(checkout, "update-ref", "HEAD", alternateSha);
+
+	const result = await runGuard(checkout, {
+		expectedSha: sha,
+		githubSha: sha,
+	});
+	assertGuardFailure(result, "CHECKOUT_HEAD_SHA_MISMATCH");
+});
+
+test("SHA guard rejects dispatches from refs other than main", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	const result = await runGuard(checkout, {
+		expectedSha: sha,
+		githubSha: sha,
+		githubRef: "refs/heads/feature",
+	});
+	assertGuardFailure(result, "INVALID_PUBLICATION_REF");
+});
+
+test("SHA guard rejects empty, short, uppercase, and non-hex expected SHAs", async (t) => {
+	const { checkout, sha } = await createCheckout(t);
+	for (const expectedSha of [
+		"",
+		sha.slice(0, 12),
+		sha.toUpperCase(),
+		`${sha.slice(0, 39)}z`,
+	]) {
+		const result = await runGuard(checkout, {
+			expectedSha,
+			githubSha: sha,
+		});
+		assertGuardFailure(result, "INVALID_EXPECTED_SHA");
+	}
+});

--- a/scripts/release/publication.mjs
+++ b/scripts/release/publication.mjs
@@ -468,56 +468,6 @@ export async function createPublicationFacts({
 	return (await loadCandidate({ root, expectedVersion, channel })).facts;
 }
 
-export async function verifyWorkflowSha({
-	root = repositoryRoot,
-	expectedSha,
-	githubSha,
-	githubRef,
-	resolveRemoteSha = async () => {
-		const { stdout } = await execFileAsync(
-			"git",
-			["rev-parse", "refs/remotes/origin/main"],
-			{ cwd: root, encoding: "utf8" },
-		);
-		return stdout.trim();
-	},
-} = {}) {
-	if (!/^[0-9a-f]{40}$/.test(expectedSha ?? "")) {
-		throw new PublicationError(
-			"INVALID_EXPECTED_SHA",
-			"expected_sha must be a full lowercase commit SHA.",
-		);
-	}
-	if (githubRef !== "refs/heads/main") {
-		throw new PublicationError(
-			"INVALID_PUBLICATION_REF",
-			"Publication must be dispatched from refs/heads/main.",
-		);
-	}
-	if (githubSha !== expectedSha) {
-		throw new PublicationError(
-			"DISPATCH_SHA_MISMATCH",
-			"expected_sha does not match the dispatch commit.",
-		);
-	}
-	let remoteMain;
-	try {
-		remoteMain = await resolveRemoteSha();
-	} catch {
-		throw new PublicationError(
-			"REMOTE_MAIN_UNAVAILABLE",
-			"Unable to resolve the fetched origin/main commit.",
-		);
-	}
-	if (remoteMain !== expectedSha) {
-		throw new PublicationError(
-			"REMOTE_MAIN_SHA_MISMATCH",
-			"expected_sha is not the current fetched origin/main commit.",
-		);
-	}
-	return { success: true, expectedSha, githubRef, remoteMain };
-}
-
 function normalizeJson(value) {
 	if (Array.isArray(value)) return value.map(normalizeJson);
 	if (!value || typeof value !== "object") return value;
@@ -2063,7 +2013,6 @@ function parseInteger(value, name) {
 function parseArguments(argv) {
 	const [command, ...argumentsList] = argv;
 	const commands = [
-		"verify-sha",
 		"preflight",
 		"prepare-artifacts",
 		"verify-artifacts",
@@ -2094,8 +2043,6 @@ function parseArguments(argv) {
 		else if (argument === "--channel" && value) options.channel = value;
 		else if (argument === "--expected-sha" && value)
 			options.expectedSha = value;
-		else if (argument === "--github-sha" && value) options.githubSha = value;
-		else if (argument === "--github-ref" && value) options.githubRef = value;
 		else if (argument === "--npm-version" && value) options.npmVersion = value;
 		else if (argument === "--artifact-dir" && value)
 			options.artifactDirectory = resolve(value);
@@ -2127,17 +2074,6 @@ function writeResult(result) {
 export async function main(argv = process.argv.slice(2)) {
 	try {
 		const options = parseArguments(argv);
-		if (options.command === "verify-sha") {
-			writeResult(
-				await verifyWorkflowSha({
-					root: options.root,
-					expectedSha: options.expectedSha,
-					githubSha: options.githubSha,
-					githubRef: options.githubRef,
-				}),
-			);
-			return;
-		}
 		if (options.command === "preflight") {
 			writeResult(
 				await createPublicationFacts({

--- a/scripts/release/publication.node-test.mjs
+++ b/scripts/release/publication.node-test.mjs
@@ -28,7 +28,6 @@ import {
 	readReleaseNotes,
 	verifyPublicationArtifacts,
 	verifyRegistry,
-	verifyWorkflowSha,
 } from "./publication.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -195,53 +194,6 @@ function registryFixture(manifest, modeByName) {
 		});
 	};
 }
-
-test("workflow SHA guard blocks ref, dispatch SHA, and approval-time main drift", async () => {
-	assert.deepEqual(
-		await verifyWorkflowSha({
-			expectedSha: SHA,
-			githubSha: SHA,
-			githubRef: "refs/heads/main",
-			resolveRemoteSha: async () => SHA,
-		}),
-		{
-			success: true,
-			expectedSha: SHA,
-			githubRef: "refs/heads/main",
-			remoteMain: SHA,
-		},
-	);
-	for (const fixture of [
-		{ expectedSha: "not-a-sha", githubSha: SHA, githubRef: "refs/heads/main" },
-		{
-			expectedSha: SHA,
-			githubSha: "b".repeat(40),
-			githubRef: "refs/heads/main",
-		},
-		{ expectedSha: SHA, githubSha: SHA, githubRef: "refs/heads/feature" },
-	]) {
-		await assert.rejects(
-			verifyWorkflowSha({
-				...fixture,
-				resolveRemoteSha: async () => SHA,
-			}),
-		);
-	}
-	let npmPublishCalls = 0;
-	await assert.rejects(
-		(async () => {
-			await verifyWorkflowSha({
-				expectedSha: SHA,
-				githubSha: SHA,
-				githubRef: "refs/heads/main",
-				resolveRemoteSha: async () => "b".repeat(40),
-			});
-			npmPublishCalls += 1;
-		})(),
-		/current fetched origin\/main commit/,
-	);
-	assert.equal(npmPublishCalls, 0);
-});
 
 test("artifact preparation rejects tracked checkout drift before pnpm pack", async (t) => {
 	const root = await createPublicationFixture(t);

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -71,6 +71,8 @@ const IMPLEMENT_AND_REVIEW_HEADINGS = [
 	"## 10. Completion gate",
 ];
 const PUBLISH_WORKFLOW_PATH = ".github/workflows/publish.yml";
+const PUBLICATION_SHA_GUARD_PATH =
+	"scripts/release/publication-sha-guard.mjs";
 const ARCHITECTURE_DOCUMENT = "docs/agents/agents-and-skills-architecture.md";
 export const EXPECTED_SKILL_ROLES = new Map([
 	["implement-and-review", "general-primary"],
@@ -253,6 +255,71 @@ function validateExactJobPermissions(
 
 export async function auditPublicationContracts(root = repositoryRoot) {
 	const failures = [];
+	const publicationShaGuardPath = join(root, PUBLICATION_SHA_GUARD_PATH);
+	if (!(await exists(publicationShaGuardPath))) {
+		failures.push(`missing zero-dependency guard ${PUBLICATION_SHA_GUARD_PATH}`);
+	} else {
+		if (!(await isGitTracked(root, PUBLICATION_SHA_GUARD_PATH))) {
+			failures.push(`${PUBLICATION_SHA_GUARD_PATH} must be tracked by Git`);
+		}
+		const guardSource = await readFile(publicationShaGuardPath, "utf8");
+		const moduleSpecifiers = [
+			...guardSource.matchAll(
+				/\b(?:import|export)\s+(?:[^"'`;]*?\s+from\s+)?["']([^"']+)["']/g,
+			),
+			...guardSource.matchAll(/\bimport\s*\(\s*["']([^"']+)["']/g),
+		].map((match) => match[1]);
+		for (const specifier of moduleSpecifiers) {
+			if (!specifier.startsWith("node:")) {
+				failures.push(
+					`${PUBLICATION_SHA_GUARD_PATH} must import only Node built-in modules; found ${specifier}`,
+				);
+			}
+		}
+		for (const [pattern, behavior] of [
+			[/\bimport\s*\(/, "dynamic import"],
+			[/\bcreateRequire\b/, "createRequire"],
+			[/\brequire\s*\(/, "require"],
+			[/\bprocess\.getBuiltinModule\b/, "process.getBuiltinModule"],
+		]) {
+			if (pattern.test(guardSource)) {
+				failures.push(
+					`${PUBLICATION_SHA_GUARD_PATH} must not use runtime module loading via ${behavior}`,
+				);
+			}
+		}
+		for (const forbidden of [
+			"publication.mjs",
+			"node_modules",
+			"semver",
+			"js-yaml",
+			"pnpm install",
+			"npm install",
+		]) {
+			if (guardSource.includes(forbidden)) {
+				failures.push(
+					`${PUBLICATION_SHA_GUARD_PATH} contains forbidden dependency behavior ${forbidden}`,
+				);
+			}
+		}
+		for (const marker of [
+			"^[0-9a-f]{40}$",
+			"refs/heads/main",
+			"DISPATCH_SHA_MISMATCH",
+			"CHECKOUT_HEAD_SHA_MISMATCH",
+			"refs/remotes/origin/main",
+			"REMOTE_MAIN_SHA_MISMATCH",
+			"JSON.stringify",
+			"process.stderr.write",
+			"process.exitCode = 1",
+		]) {
+			if (!guardSource.includes(marker)) {
+				failures.push(
+					`${PUBLICATION_SHA_GUARD_PATH} is missing zero-dependency SHA behavior ${marker}`,
+				);
+			}
+		}
+	}
 	const document = await readWorkflowDocument(
 		root,
 		PUBLISH_WORKFLOW_PATH,
@@ -432,7 +499,7 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 	const preflightRuns = workflowRunText(preflight);
 	for (const marker of [
 		"git fetch --no-tags origin main",
-		"publication.mjs verify-sha",
+		"publication-sha-guard.mjs",
 		`--expected-sha "${DOLLAR_SIGN}{EXPECTED_SHA}"`,
 		`--github-sha "${DOLLAR_SIGN}{GITHUB_SHA}"`,
 		`--github-ref "${DOLLAR_SIGN}{GITHUB_REF}"`,
@@ -458,7 +525,7 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 		guardStep.env?.EXPECTED_SHA !== `${DOLLAR_SIGN}{{ inputs.expected_sha }}` ||
 		typeof guardStep.run !== "string" ||
 		!guardStep.run.includes(
-			'guard="$(node scripts/release/publication.mjs verify-sha',
+			'guard="$(node scripts/release/publication-sha-guard.mjs',
 		)
 	) {
 		failures.push(
@@ -468,6 +535,22 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 	const preflightSteps = Array.isArray(preflight?.steps)
 		? preflight.steps
 		: [];
+	const guardStepIndex = preflightSteps.indexOf(guardStep);
+	const firstInstallIndex = preflightSteps.findIndex(
+		(step) =>
+			isMapping(step) &&
+			typeof step.run === "string" &&
+			/\bpnpm install\b/.test(step.run),
+	);
+	if (
+		guardStepIndex < 0 ||
+		firstInstallIndex < 0 ||
+		firstInstallIndex <= guardStepIndex
+	) {
+		failures.push(
+			`${PUBLISH_WORKFLOW_PATH} preflight dependency installation must remain after the zero-dependency SHA guard`,
+		);
+	}
 	const readinessStep = preflightSteps.find(
 		(step) => isMapping(step) && step.id === "release-readiness",
 	);
@@ -727,7 +810,7 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 	const approvalGuard = publishSteps[approvalGuardIndex];
 	for (const marker of [
 		"git fetch --no-tags origin main",
-		"publication.mjs verify-sha",
+		"publication-sha-guard.mjs",
 		`--expected-sha "${DOLLAR_SIGN}{EXPECTED_SHA}"`,
 		`--github-sha "${DOLLAR_SIGN}{GITHUB_SHA}"`,
 		`--github-ref "${DOLLAR_SIGN}{GITHUB_REF}"`,
@@ -740,6 +823,17 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 				`${PUBLISH_WORKFLOW_PATH} approval-time current-main guard is missing ${marker}`,
 			);
 		}
+	}
+	const publishInstallIndex = publishSteps.findIndex(
+		(step) =>
+			isMapping(step) &&
+			typeof step.run === "string" &&
+			/\bpnpm install\b/.test(step.run),
+	);
+	if (publishInstallIndex < 0 || approvalGuardIndex >= publishInstallIndex) {
+		failures.push(
+			`${PUBLISH_WORKFLOW_PATH} approval-time zero-dependency SHA guard must run before dependency installation`,
+		);
 	}
 	const remoteReleaseGuard = publishSteps[remoteReleaseGuardIndex];
 	for (const marker of [
@@ -945,6 +1039,7 @@ export async function auditPublicationContracts(root = repositoryRoot) {
 		}
 	}
 	for (const forbidden of [
+		"verify-sha",
 		"publishWithChangesetsNpm",
 		"runChangesetsPublish",
 		"manifest.packageManager",

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -241,6 +241,7 @@ async function createPublicationContractFixture(t) {
 		".github/pull_request_template.md",
 		"package.json",
 		"pnpm-lock.yaml",
+		"scripts/release/publication-sha-guard.mjs",
 		"scripts/release/publication.mjs",
 	]) {
 		await writeFixtureFile(
@@ -1013,6 +1014,112 @@ test("publication contract rejects tarball pipeline and approval-time SHA regres
 			{ failures: await auditPublicationContracts(root) },
 			fixture.failure,
 		);
+	}
+});
+
+test("publication contract preserves the zero-dependency SHA guard", async (t) => {
+	await t.test("guard file deletion", async (t) => {
+		const root = await createPublicationContractFixture(t);
+		await rm(join(root, "scripts/release/publication-sha-guard.mjs"));
+		await git(
+			root,
+			"add",
+			"--update",
+			"--",
+			"scripts/release/publication-sha-guard.mjs",
+		);
+		assertFailure(
+			{ failures: await auditPublicationContracts(root) },
+			/missing zero-dependency guard/,
+		);
+	});
+
+	await t.test("workflow reverts to publication.mjs verify-sha", async (t) => {
+		const root = await createPublicationContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			".github/workflows/publish.yml",
+			(contents) =>
+				contents.replaceAll(
+					"publication-sha-guard.mjs",
+					"publication.mjs verify-sha",
+				),
+		);
+		assertFailure(
+			{ failures: await auditPublicationContracts(root) },
+			/missing blocking behavior publication-sha-guard|guard must bind|current-main guard is missing/,
+		);
+	});
+
+	await t.test("dependency installation moves before the first guard", async (t) => {
+		const root = await createPublicationContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			".github/workflows/publish.yml",
+			(contents) =>
+				contents.replace(
+					'          guard="$(node scripts/release/publication-sha-guard.mjs \\\n',
+					'          pnpm install --frozen-lockfile\n          guard="$(node scripts/release/publication-sha-guard.mjs \\\n',
+				),
+		);
+		assertFailure(
+			{ failures: await auditPublicationContracts(root) },
+			/dependency installation must remain after the zero-dependency SHA guard/,
+		);
+	});
+
+	await t.test("approval-time guard is removed", async (t) => {
+		const root = await createPublicationContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			".github/workflows/publish.yml",
+			(contents) =>
+				contents.replace(
+					"        id: approval-sha-guard\n",
+					"        id: removed-approval-sha-guard\n",
+				),
+		);
+		assertFailure(
+			{ failures: await auditPublicationContracts(root) },
+			/must revalidate current main|approval-time zero-dependency SHA guard/,
+		);
+	});
+
+	await t.test("guard imports a bare package", async (t) => {
+		const root = await createPublicationContractFixture(t);
+		await mutateTrackedFixture(
+			root,
+			"scripts/release/publication-sha-guard.mjs",
+			(contents) => `${contents}\nimport semver from "semver";\n`,
+		);
+		assertFailure(
+			{ failures: await auditPublicationContracts(root) },
+			/must import only Node built-in modules; found semver|forbidden dependency behavior semver/,
+		);
+	});
+
+	for (const [name, appendedSource] of [
+		[
+			"guard uses createRequire",
+			'import { createRequire } from "node:module";\nconst loadPackage = createRequire(import.meta.url);\nloadPackage("third-party");',
+		],
+		[
+			"guard uses a variable dynamic import",
+			'const packageName = "third-party";\nawait import(packageName);',
+		],
+	]) {
+		await t.test(name, async (t) => {
+			const root = await createPublicationContractFixture(t);
+			await mutateTrackedFixture(
+				root,
+				"scripts/release/publication-sha-guard.mjs",
+				(contents) => `${contents}\n${appendedSource}\n`,
+			);
+			assertFailure(
+				{ failures: await auditPublicationContracts(root) },
+				/must not use runtime module loading/,
+			);
+		});
 	}
 });
 


### PR DESCRIPTION
## Summary

Fix the deterministic Publish Packages failure in run 30605142371 by moving SHA verification to a single-purpose Node built-in-only guard that runs before dependency installation.

## Scope

- add a zero-third-party-dependency publication SHA guard
- use it for preflight and post-Environment-approval checks
- remove the duplicate publication.mjs verify-sha path
- add real no-node_modules tests and repository contract regressions

## Non-goals

- no npm publication, dist-tag mutation, Git tag, GitHub Release, or workflow rerun
- no public package runtime changes

## Public impact

Internal release Workflow safety only; no public package runtime/API change.

## Changeset

- [ ] Added
- [x] Not required — internal publication Workflow and safety-script fix only

## Validation

| Command | Result |
| --- | --- |
| node --test scripts/release/publication-sha-guard.node-test.mjs | PASS (6/6; temporary checkout has no node_modules) |
| node --test scripts/release/publication.node-test.mjs | PASS (11/11) |
| node --test scripts/repository-contract.node-test.mjs | PASS (73/73) |
| pnpm test:release-scripts | PASS (137/137) |
| pnpm verify:repository-contract | PASS |
| pnpm lint:changed --base 9b58c62306458503473d641023de7221d857062a | PASS |
| pnpm lint:ci | PASS |
| pnpm typecheck | PASS |
| pnpm test:vitest | PASS (98 files passed, 1 skipped; 653 tests passed, 2 skipped) |
| git diff --check | PASS |
| commit hook: pnpm verify:precommit | PASS |

## Autonomous review

- Review rounds: 2 read-only full-diff reviews
- Remaining P0 / P1 / P2: 0 / 0 / 0

## Remote state

- Local reviewed SHA: 3aa422462e14967c62e4b9b916e4a5834bacc7c3
- PR head SHA: 3aa422462e14967c62e4b9b916e4a5834bacc7c3
- Remote CI: PASS (all executed checks passed; bounded stress check skipped by workflow policy)

## External operations

- Commit: 3aa422462e14967c62e4b9b916e4a5834bacc7c3
- Push: codex/fix-publication-sha-guard
- PR state: Draft
- Publication / tag / GitHub Release: not performed