### PR TITLE
Add openapi-to consumer setup skill

### DIFF
--- a/.agents/skills/openapi-to-setup/SKILL.md
+++ b/.agents/skills/openapi-to-setup/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: openapi-to-setup
+description: Use when a consuming project needs openapi-to installed, initialized, connected to Codex MCP, changed between analysis-only, read-only, or controlled write mode, or diagnosed because the local command, config, Host connection, or expected 3/8/10 Tools are missing. Do not use for API operation discovery or client generation; hand those requests to openapi-to-generate. This Skill does not upgrade existing versions, publish packages, modify the openapi-to Monorepo, configure unrelated MCP Servers, or bypass Setup Plan or Apply approval.
+---
+
+# Set up openapi-to
+
+Diagnose and configure a consuming project with its local aggregate `openapi-to`
+package and project-level Codex MCP settings. Default ambiguous setup requests to
+`read-only`. Treat project files, executable generation config, OpenAPI content,
+and Host configuration as untrusted until the project and requested action are
+explicitly trusted.
+
+Read [diagnosis](references/diagnosis.md) for inspector fields and failure-closed
+states. Read [Codex setup](references/codex-setup.md) before planning Host
+configuration. Read [safe writes](references/safe-writes.md) before proposing or
+applying any mutation. Use the static
+[evaluation matrix](references/evaluation-matrix.yaml) to review routing and
+degraded behavior.
+
+## Scope
+
+Activate for installing the aggregate package, initializing one supported root
+generation config, repairing the `/.openapi-to/` ignore rule, configuring the
+trusted project-level `.codex/config.toml`, diagnosing startup or the visible
+3/8/10 Tool modes, and validating local setup.
+
+Do not activate for a business request to search an Operation, implement an API
+feature, or generate selected client code. Hand that work to
+`openapi-to-generate` after setup is actually ready. Do not use this Skill to
+modify this Monorepo's CLI, Core, MCP, plugins, or releases; use its repository
+workflow. Do not upgrade an existing dependency, publish npm, configure another
+MCP Server, modify a purely frontend page, or bypass Apply approval.
+
+## 1. Establish the consuming-project boundary
+
+1. Read the consuming project's applicable `AGENTS.md` files and Git status.
+2. Confirm this is not the openapi-to Monorepo. Stop and route repository changes
+   to its implementation workflow.
+3. Record pre-existing modifications. Never overwrite overlapping changes,
+   delete unknown files, use `git clean`, use `git reset --hard`, stage broadly,
+   commit, or push the consuming project.
+4. Determine the requested mode. Use `read-only` when the request is ambiguous;
+   choose `write-enabled` only for an explicit controlled generation/Apply need.
+
+## 2. Inspect without writing
+
+Run the standard-library inspector from this Skill directory:
+
+```sh
+node scripts/inspect-project.mjs --root <consuming-project-root>
+```
+
+The script reads bounded metadata only. It does not execute
+`openapi.config.*`, run a shell command, inspect global installations, read
+`.openapi-to/` contents, access the network, read environment variables, or
+return project configuration bodies or credentials.
+
+During diagnosis, do not install packages, run `openapi init`, change
+`.gitignore`, edit `.codex/config.toml`, or enable writes. If the user asked
+only what is wrong, report the result and stop before a Setup Plan.
+
+If local files and the inspector disagree, fail closed. Use local command help
+only after confirming the command resolves from this project; command help is
+read-only and must not fall back to a global binary.
+
+## 3. Classify distinct states
+
+Keep these states separate:
+
+```text
+UNINSPECTED -> BLOCKED | PACKAGE_MISSING | PACKAGE_READY
+PACKAGE_READY -> CONFIG_MISSING | CONFIG_READY
+CONFIG_READY -> HOST_CONFIG_MISSING | HOST_CONFIG_READY
+HOST_CONFIG_READY -> RESTART_REQUIRED
+restarted and inspected -> MCP_ANALYSIS_ONLY | MCP_READ_ONLY | MCP_WRITE_ENABLED
+```
+
+Package declaration, a config filename, local command resolution, Host file
+configuration, Host restart, Server connection, and verified Tool capability
+are different evidence. Writing `.codex/config.toml` always yields
+`RESTART_REQUIRED`; it never proves the running Host reloaded the Server.
+
+## 4. Plan the minimum setup
+
+Use three target modes:
+
+- `analysis-only`: no generation config; oriented around three analysis Tools.
+- `read-only`: the default; aggregate package, one trusted config, and configured
+  MCP without `--allow-write`; oriented around eight Tools.
+- `write-enabled`: explicit only; configured MCP with `--allow-write` and
+  `openapi_apply_generation` retained in `approval_mode = "prompt"`; oriented
+  around ten Tools.
+
+Tool counts are directional. Capability is established by the actual Tool list,
+current Tool inputSchema, and returned capability fields.
+
+For a missing package, prefer an exact user-selected version, then an exact
+consistent local `@openapi-to/*` version, otherwise stop for a version decision.
+Never choose `latest`, a prerelease, or an upgrade implicitly. For pnpm, the
+supported action is:
+
+```sh
+pnpm add -D --save-exact openapi-to@<exact-version>
+```
+
+Do not use a global installation or substitute `@openapi-to/mcp` for a complete
+business code-generation environment. Automatic package mutation is supported
+for pnpm only in this phase. Diagnose npm, Yarn, and Bun, but keep their writes
+manual unless a later version adds tested support.
+
+When generation config is missing, plan the existing command exactly:
+
+```sh
+pnpm exec openapi init
+```
+
+Do not invent `--yes`, `--force`, or another initializer. It creates
+`openapi.config.ts` for ESM or `openapi.config.js` otherwise, refuses any
+existing supported root config, and adds `/.openapi-to/` only after config
+creation. Do not use the retired `.OpenAPI/` config directory. Never
+overwrite one config or choose among multiple configs.
+
+## 5. Bind every write to an exact Setup Plan
+
+Before any install, init, ignore, or Codex configuration write:
+
+1. Re-run the inspector and capture its exact `observedStateHash`.
+2. Re-read Git status and stop on overlapping changes.
+3. Build one bounded JSON Setup Plan with argv arrays, network flags, exact
+   package/version, exact relative expected writes, verification, and restart.
+4. Show the complete plan plus exact diffs for direct file edits and expected
+   writes for package-manager or init commands.
+5. Hash it with `node scripts/hash-setup-plan.mjs` using stdin or `--file`.
+6. Wait for `批准执行 Setup Plan <exact-setupPlanId>` or an equally explicit
+   statement naming that exact ID.
+
+“Continue”, “install it”, “use defaults”, “looks good”, or “fix it” is not
+approval. Never run diagnosis, install, init, and Host edits as an automatic
+chain. If `package.json`, a lockfile, generation config, `.gitignore`, Codex
+config, or overlapping Git state changes, re-inspect, create a new plan and ID,
+show it, and obtain new exact approval.
+
+## 6. Apply only the approved actions
+
+Execute only action objects in the approved current plan. Package installation
+may use network only when the plan says so. Run init through the existing CLI.
+Create a missing Codex file or append one exact section while preserving all
+existing bytes and unknown sections. Do not parse and rewrite arbitrary TOML.
+
+If `.codex/config.toml` already contains an `openapi_to` section, duplicated
+section, absolute path, unrecognized shape, or unsafe write-mode policy, require
+manual review and do not overwrite or delete it. Never write credentials,
+headers, environment entries, remote-policy relaxations, machine-specific
+absolute paths, or user-level Codex configuration.
+
+## 7. Verify writes and the restart boundary
+
+Review the complete post-write Git diff and separate pre-existing changes from
+approved setup changes. Verify as applicable:
+
+```sh
+pnpm exec openapi --version
+pnpm exec openapi-to-mcp --help
+```
+
+Confirm one supported config, `/.openapi-to/` ignored, no retired config path,
+the exact approved Codex bytes, no duplicate section or credential, and prompt
+approval in write-enabled mode. Re-run the inspector. Any Host-config change
+returns `RESTART_REQUIRED` and stops.
+
+After the user restarts Codex, inspect the connected Server's actual Tool list
+and relevant current inputSchema. Classify three compatible analysis Tools as
+`MCP_ANALYSIS_ONLY`, eight compatible read-only Tools as `MCP_READ_ONLY`, and ten
+compatible Tools including Prepare/Apply as `MCP_WRITE_ENABLED`. A count with
+missing or incompatible Schema is `BLOCKED` or unknown, not ready.
+
+## 8. Hand off generation
+
+This Skill must not call `openapi_search_operations`, `openapi_get_operation`,
+`openapi_generate_dry_run`, `openapi_prepare_generation`, or
+`openapi_apply_generation` to deliver a business feature. Once read-only setup
+is verified, hand discovery and preview to `openapi-to-generate`; once
+write-enabled setup is verified, hand its controlled Prepare/Apply workflow to
+that Skill. Do not cross the restart boundary on the user's behalf.
+
+## Completion
+
+Report the requested and observed mode, state transitions, inspector hash,
+approved Setup Plan ID when writes occurred, exact files/commands/network use,
+post-write validation, pre-existing changes, `RESTART_REQUIRED` when applicable,
+actual Tools and Schema evidence after restart, and any manual follow-up. Setup
+is complete only at the requested verified MCP state.

--- a/.agents/skills/openapi-to-setup/agents/openai.yaml
+++ b/.agents/skills/openapi-to-setup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Set up openapi-to"
+  short_description: "Diagnose and configure local openapi-to and Codex MCP"
+  default_prompt: "Use $openapi-to-setup to inspect this consuming project, prepare a bounded setup plan, and apply only the explicitly approved installation or configuration changes."

--- a/.agents/skills/openapi-to-setup/references/codex-setup.md
+++ b/.agents/skills/openapi-to-setup/references/codex-setup.md
@@ -1,0 +1,115 @@
+# Codex project setup
+
+Automatic Host configuration in this phase is Codex-first and limited to the
+trusted consuming project's `.codex/config.toml`. Claude Code, Cursor, and
+generic stdio Hosts keep their existing documentation and require manual Host
+configuration.
+
+## macOS and Linux
+
+Analysis-only (three Tools) omits `--config`:
+
+```toml
+[mcp_servers.openapi_to]
+command = "pnpm"
+args = ["exec", "openapi-to-mcp", "--workspace-root", "."]
+cwd = "."
+startup_timeout_sec = 10
+tool_timeout_sec = 60
+```
+
+Read-only is the default for an ambiguous setup request:
+
+```toml
+[mcp_servers.openapi_to]
+command = "pnpm"
+args = [
+  "exec",
+  "openapi-to-mcp",
+  "--workspace-root",
+  ".",
+  "--config",
+  "openapi.config.ts"
+]
+cwd = "."
+startup_timeout_sec = 10
+tool_timeout_sec = 60
+```
+
+Use the exact discovered config filename when it is `.js`, `.cjs`, or `.mjs`.
+Do not invent or rename a config.
+
+Write-enabled requires explicit user intent, adds `--allow-write`, and keeps
+Apply in prompt approval mode:
+
+```toml
+[mcp_servers.openapi_to]
+command = "pnpm"
+args = [
+  "exec",
+  "openapi-to-mcp",
+  "--workspace-root",
+  ".",
+  "--config",
+  "openapi.config.ts",
+  "--allow-write"
+]
+cwd = "."
+startup_timeout_sec = 10
+tool_timeout_sec = 60
+
+[mcp_servers.openapi_to.tools.openapi_apply_generation]
+approval_mode = "prompt"
+```
+
+`--allow-write` grants Server capability only. It is not approval of a Setup
+Plan and not approval of an MCP generation Apply plan.
+
+## Native Windows
+
+Use the repository's verified `cmd.exe` form because Hosts may not execute the
+pnpm `.cmd` shim directly. The read-only section is:
+
+```toml
+[mcp_servers.openapi_to]
+command = "cmd.exe"
+args = ["/d", "/s", "/c", "pnpm exec openapi-to-mcp --workspace-root . --config openapi.config.ts"]
+cwd = "."
+startup_timeout_sec = 10
+tool_timeout_sec = 60
+```
+
+For explicit write-enabled mode, add `--allow-write` inside the final command
+string and the same prompt section shown above. Do not use POSIX absolute paths
+or machine-specific Node paths.
+
+## File handling
+
+- Missing file: a specifically approved plan may create the complete file.
+- Existing file without `openapi_to`: an approved plan may append the exact
+  bytes, preserving the original bytes and unknown sections and adding only the
+  necessary newline separator.
+- Existing `openapi_to` section: manual review by default. Do not overwrite,
+  remove, reorder, or parse-and-rewrite the file.
+- Duplicate section, absolute path, `--allow-write` without Apply prompt, or
+  unrecognized structure: report `manualReviewRequired` and an advisory diff;
+  do not apply automatically.
+
+Never write environment values, headers, credentials, remote-network policy,
+user-level Codex config, or unrelated MCP Server configuration.
+
+## Restart and capability verification
+
+Every Codex config write returns `RESTART_REQUIRED`. After the user restarts,
+use Codex MCP status to verify the Server is connected, list actual Tool names,
+and inspect relevant inputSchema:
+
+| Directional count | Required capability evidence | State |
+| ---: | --- | --- |
+| 3 | validate, inspect, and diff names plus compatible current Schemas | `MCP_ANALYSIS_ONLY` |
+| 8 | the three analysis Tools plus configured catalog/search/contract/dry-run/check Tools and compatible Schemas | `MCP_READ_ONLY` |
+| 10 | the read-only set plus Prepare/Apply and compatible Schemas; Host Apply prompt remains enabled | `MCP_WRITE_ENABLED` |
+
+Any other count is unknown. A matching count with missing names or incompatible
+inputSchema is also unknown or `BLOCKED`. Tool results' capability fields take
+part in the decision. Do not infer current-version arguments from names alone.

--- a/.agents/skills/openapi-to-setup/references/diagnosis.md
+++ b/.agents/skills/openapi-to-setup/references/diagnosis.md
@@ -1,0 +1,74 @@
+# Setup diagnosis
+
+Use the inspector before suggesting a write. Its JSON is a bounded observation,
+not proof that a command started, a Host reloaded configuration, or an MCP Tool
+Schema is compatible.
+
+## State model
+
+| State | Evidence | Next decision |
+| --- | --- | --- |
+| `UNINSPECTED` | No current inspector result | Read rules, Git state, and run the inspector. |
+| `BLOCKED` | Conflicting package-manager evidence, multiple configs, unsafe symlink, oversized/invalid metadata, version conflict, or duplicate Codex section | Stop writes and report the exact bounded reason. |
+| `PACKAGE_MISSING` | No aggregate `openapi-to` declaration | Plan an exact-version aggregate install or request a version decision. |
+| `PACKAGE_READY` | Aggregate package is declared locally | Continue to generation config; do not infer that binaries resolve. |
+| `CONFIG_MISSING` | No supported root config | Plan the existing `pnpm exec openapi init`. |
+| `CONFIG_READY` | Exactly one supported config exists | Treat it as trusted executable project code only when validation is approved. |
+| `HOST_CONFIG_MISSING` | No project Codex server section | Plan a missing-file create or exact append. |
+| `HOST_CONFIG_READY` | One conservatively recognized server section | Restart may still be required; existing sections default to manual review. |
+| `RESTART_REQUIRED` | Project Host configuration changed | Stop until the user restarts the Host. |
+| `MCP_ANALYSIS_ONLY` | Compatible current analysis Tool list and Schemas | Validation/inspection/diff only. |
+| `MCP_READ_ONLY` | Compatible configured read-only Tool list and Schemas | Hand discovery/preview to `openapi-to-generate`. |
+| `MCP_WRITE_ENABLED` | Compatible Prepare/Apply list and Schemas plus prompt policy | Hand controlled generation to `openapi-to-generate`; Apply still needs exact approval. |
+
+## Inspector envelope
+
+- `schemaVersion` identifies the JSON contract.
+- `observedStateHash` is SHA-256 over the canonical observation without the
+  hash. Bind a Setup Plan to this exact value.
+- `blockingReasons` is sorted and closed: do not guess through a reason.
+- `workspace` reports only bounded booleans, a relative root marker, and the
+  running Node major/support decision. It never prints the absolute Workspace.
+- `packageManager` prefers `package.json#packageManager`, then a unique lockfile
+  manager. A mismatch or multiple managers is `conflict`; only pnpm is an
+  automatic write path in this phase.
+- `dependencies` lists only manifest declarations for `openapi-to` and
+  `@openapi-to/*`, their dependency section and range. It does not inspect a
+  global installation or claim that a declared package resolves.
+- `generationConfig` checks only `openapi.config.ts`, `.js`, `.cjs`, and `.mjs`
+  at the root. It hashes bytes without importing or executing the file.
+- `runtimeState` checks `.openapi-to/` presence and a conservative explicit
+  root ignore rule. It never reads state contents.
+- `codex` hashes `.codex/config.toml` and uses conservative section/text
+  inspection. It never returns TOML content, credentials, command bodies, or
+  environment data. `parser: conservative-text-inspection` is deliberately not
+  a claim of complete TOML parsing. `manualReviewRequired` prevents automatic
+  rewriting of an existing section; `configurationBlocked` separately marks a
+  shape or policy that cannot be treated as safe current Host configuration.
+
+## Package boundaries
+
+The aggregate `openapi-to` package provides the `openapi`, `openapi-to`, and
+`openapi-to-mcp` binaries plus official generation plugins. `@openapi-to/mcp`
+alone is an advanced MCP-only boundary, not a complete business
+code-generation environment. Report MCP-only state; do not silently replace it
+or install over it.
+
+Existing versions are immutable in this workflow. Exact user choice outranks
+an exact, consistent local `@openapi-to/*` version. Without either, request a
+version decision. Ranges, tags, `latest`, prereleases, and global commands do
+not supply safe version evidence.
+
+## Failure-closed rules
+
+- More than one supported generation config is `BLOCKED`; do not select one.
+- An invalid/oversized package, config, ignore, or Codex metadata file is
+  `BLOCKED`; do not truncate and proceed.
+- A symlink that resolves outside the real project root is `BLOCKED` and is not
+  followed.
+- A Codex section the conservative inspector cannot understand is
+  `manualReviewRequired`; do not rewrite arbitrary TOML.
+- A package declaration is not command resolution. A Host section is not a
+  restart. A Tool count is not Schema compatibility.
+- If the user requested diagnosis only, stop after reporting the state and do
+  not prepare or apply writes.

--- a/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
@@ -1,0 +1,162 @@
+schema_version: 1
+kind: static_skill_evaluation_inputs
+cases:
+  - id: trigger-configure-frontend
+    category: trigger
+    prompt: "在这个前端项目里配置 openapi-to"
+    expected: activate_default_read_only
+  - id: trigger-connect-codex
+    category: trigger
+    prompt: "帮我接入 openapi-to MCP"
+    expected: activate
+  - id: trigger-server-missing
+    category: trigger
+    prompt: "为什么 Codex 里看不到 openapi-to"
+    expected: activate_diagnosis
+  - id: trigger-three-tools
+    category: trigger
+    prompt: "为什么只有 3 个 Tool"
+    expected: activate_diagnosis
+  - id: trigger-read-only
+    category: trigger
+    prompt: "把 openapi-to 配置成只读模式"
+    expected: activate_read_only
+  - id: trigger-write-enabled
+    category: trigger
+    prompt: "启用 openapi-to 的安全生成写入能力"
+    expected: activate_write_enabled
+  - id: trigger-check-config
+    category: trigger
+    prompt: "检查当前项目的 openapi-to 配置是否正确"
+    expected: activate_diagnosis
+  - id: trigger-gitignore
+    category: trigger
+    prompt: "修复缺失的 .openapi-to gitignore"
+    expected: activate_plan_required
+
+  - id: reject-user-delete
+    category: reject
+    prompt: "根据接口实现用户删除功能"
+    expected: handoff_openapi_to_generate
+  - id: reject-order-export
+    category: reject
+    prompt: "搜索订单导出接口"
+    expected: handoff_openapi_to_generate
+  - id: reject-selected-client
+    category: reject
+    prompt: "生成这三个 operation 的客户端代码"
+    expected: handoff_openapi_to_generate
+  - id: reject-monorepo-mcp
+    category: reject
+    prompt: "修改 openapi-to Monorepo 的 MCP Tool"
+    expected: route_repository_workflow
+  - id: reject-upgrade
+    category: reject
+    prompt: "把当前项目的 openapi-to 升级到最新版"
+    expected: do_not_activate_upgrade
+  - id: reject-publish
+    category: reject
+    prompt: "发布 openapi-to 到 npm"
+    expected: do_not_activate
+  - id: reject-other-server
+    category: reject
+    prompt: "配置另一个无关 MCP Server"
+    expected: do_not_activate
+  - id: reject-frontend-layout
+    category: reject
+    prompt: "修改纯前端页面布局"
+    expected: do_not_activate
+
+  - id: degraded-package-missing
+    category: degraded
+    prompt: "项目没有 openapi-to，版本也没有指定"
+    expected: request_exact_version_before_install
+  - id: degraded-global-only
+    category: degraded
+    prompt: "全局 openapi 命令存在，但项目 manifest 没有依赖"
+    expected: treat_local_package_as_missing
+  - id: degraded-mcp-only
+    category: degraded
+    prompt: "项目只有 @openapi-to/mcp"
+    expected: report_mcp_only_boundary
+  - id: degraded-package-manager-conflict
+    category: degraded
+    prompt: "packageManager 写 pnpm，但只存在 yarn.lock"
+    expected: block_without_guessing
+  - id: degraded-multiple-lockfiles
+    category: degraded
+    prompt: "项目同时存在 pnpm-lock.yaml 和 package-lock.json"
+    expected: block_without_guessing
+  - id: degraded-multiple-configs
+    category: degraded
+    prompt: "根目录同时存在 openapi.config.ts 和 openapi.config.js"
+    expected: block_without_executing_or_selecting
+  - id: degraded-config-missing
+    category: degraded
+    prompt: "项目已经安装 aggregate package，但没有 generation config"
+    expected: plan_existing_init_after_exact_approval
+  - id: degraded-existing-config
+    category: degraded
+    prompt: "已经有一个 openapi.config.ts，重新初始化"
+    expected: refuse_overwrite_and_do_not_init
+  - id: degraded-gitignore-missing
+    category: degraded
+    prompt: "配置已存在，但 .openapi-to 没有被 gitignore"
+    expected: plan_exact_ignore_append_after_approval
+  - id: degraded-codex-missing
+    category: degraded
+    prompt: "项目没有 .codex/config.toml"
+    expected: plan_project_level_codex_file_after_approval
+  - id: degraded-codex-other-server
+    category: degraded
+    prompt: "Codex 配置已有其他 Server，但没有 openapi_to"
+    expected: preserve_existing_bytes_and_plan_exact_append
+  - id: degraded-existing-codex-section
+    category: degraded
+    prompt: "已有 openapi_to section，自动替换成新模板"
+    expected: manual_review_no_rewrite
+  - id: degraded-absolute-codex-path
+    category: degraded
+    prompt: "openapi_to section 使用机器绝对路径"
+    expected: manual_review_required
+  - id: degraded-write-without-prompt
+    category: degraded
+    prompt: "已经有 --allow-write，但没有 Apply prompt"
+    expected: block_write_ready_claim
+  - id: degraded-not-restarted
+    category: degraded
+    prompt: "刚修改 .codex/config.toml，Host 还没重启"
+    expected: restart_required
+  - id: degraded-count-schema-mismatch
+    category: degraded
+    prompt: "Tool 数量是 10，但 Apply inputSchema 不兼容"
+    expected: block_capability_claim
+  - id: degraded-windows
+    category: degraded
+    prompt: "在 Windows Codex 项目中配置只读 MCP"
+    expected: use_cmd_exe_template
+
+  - id: approval-exact
+    category: write-approval
+    prompt: "批准执行 Setup Plan aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    expected: apply_only_matching_current_plan
+  - id: approval-continue
+    category: write-approval
+    prompt: "继续"
+    expected: reject_as_approval
+  - id: approval-defaults
+    category: write-approval
+    prompt: "按默认来"
+    expected: reject_as_approval
+  - id: approval-install
+    category: write-approval
+    prompt: "安装吧"
+    expected: reject_as_approval
+  - id: approval-state-drift
+    category: write-approval
+    prompt: "计划后 package.json 已变化，但仍批准旧 ID"
+    expected: replan_and_require_new_exact_approval
+  - id: approval-two-plans
+    category: write-approval
+    prompt: "上下文有两个 Setup Plan，执行它"
+    expected: require_one_exact_current_id

--- a/.agents/skills/openapi-to-setup/references/safe-writes.md
+++ b/.agents/skills/openapi-to-setup/references/safe-writes.md
@@ -1,0 +1,117 @@
+# Safe setup writes
+
+Every package install, initializer run, `.gitignore` change, and Codex config
+change is a write. Diagnosis never implies authorization for one.
+
+## Setup Plan schema
+
+A plan is bounded JSON with at least:
+
+```json
+{
+  "schemaVersion": 1,
+  "mode": "read-only",
+  "observedStateHash": "<lowercase-sha256>",
+  "packageManager": "pnpm",
+  "actions": [],
+  "verification": [],
+  "restartRequired": true
+}
+```
+
+Represent commands as program plus argv, not shell source:
+
+```json
+{
+  "kind": "run-command",
+  "command": "pnpm",
+  "args": ["exec", "openapi", "init"],
+  "network": false,
+  "expectedWrites": ["openapi.config.ts", ".gitignore"]
+}
+```
+
+Supported action kinds are `run-command`, `create-file`, `append-file`,
+`update-gitignore`, and `manual-review`. Direct file actions name a relative
+project target and carry or accompany the exact proposed diff. A plan must not
+contain absolute/escaping target paths or sensitive fields named `token`,
+`authorization`, `cookie`, `secret`, `password`, `headers`, or `env`.
+
+Hash the complete plan with:
+
+```sh
+node scripts/hash-setup-plan.mjs < setup-plan.json
+node scripts/hash-setup-plan.mjs --file setup-plan.json
+```
+
+The script validates the base Schema, recursively sorts object keys, preserves
+array order, emits canonical JSON, and returns SHA-256 `setupPlanId`. Its
+256-KiB input bound and maximum array sizes prevent an unbounded approval
+record. It never executes a command, accesses the network, reads environment
+variables, or writes a file.
+
+## Exact approval and drift
+
+Display the full plan, exact direct-edit diff, command argv, network flag,
+package/version decision, expected package-manager/init writes, verification,
+and `setupPlanId`. Accept only explicit approval naming that exact ID, such as:
+
+```text
+批准执行 Setup Plan <exact-setupPlanId>
+```
+
+“Continue”, “install”, “configure it”, “looks good”, and “use defaults” are not
+approval. Before applying, re-run the inspector and require the same
+`observedStateHash`. Re-read Git status. Drift in the manifest, lockfile,
+generation config, ignore file, Codex file, or overlapping worktree invalidates
+the plan. Re-plan, re-hash, re-display, and obtain new exact approval.
+
+## Package install
+
+Only pnpm is automatically supported in this phase. Use the exact package and
+version shown in the plan:
+
+```sh
+pnpm add -D --save-exact openapi-to@<exact-version>
+```
+
+The plan marks `network: true` and expects `package.json` plus
+`pnpm-lock.yaml`. Never use global install, a floating tag, a prerelease without
+explicit selection, `@openapi-to/mcp` as an aggregate substitute, or an
+implicit upgrade. Review the actual diff because package-manager changes are
+not automatically attributable to the Skill.
+
+## Initializer and ignore rule
+
+Use only `pnpm exec openapi init`. It has no supported non-interactive override
+or force option. It creates `.ts` for an ESM package or `.js` otherwise, refuses
+all existing `.ts`/`.js`/`.cjs`/`.mjs` candidates, and then appends
+`/.openapi-to/` if absent. It does not create `.openapi-to/`. Do not handwrite a
+parallel generation template or use `.OpenAPI/openapi.config.ts`.
+
+If a config already exists, do not run init. If several exist, stop. If the
+config exists but the ignore rule alone is missing, an exact approved
+`update-gitignore` action may append only the rule with a reasonable newline;
+preserve all existing bytes.
+
+## Codex config
+
+Create a missing project file or append one exact absent section only after
+approval. Preserve existing bytes and unknown sections; never reorder the
+document. Existing `openapi_to` sections, duplicates, unusual TOML, or unsafe
+mode policy require manual review. Never implement an incomplete TOML rewriter.
+
+The config must use project-local package-manager resolution, relative paths,
+no credentials or remote-policy relaxation, and no `--allow-write` by default.
+Write-enabled mode requires explicit intent and the Apply prompt section.
+
+## Post-write review
+
+Inspect the full worktree diff and classify every changed path as pre-existing,
+approved direct edit, expected command output, or unexpected. Stop on overlap
+or unexpected writes. Validate local commands, one config, ignore state, exact
+Codex bytes, no duplicate/absolute/credential content, and Apply prompt when
+applicable. Re-run the inspector. Never commit or push the consuming project.
+
+Host configuration changes end at `RESTART_REQUIRED`. Only post-restart Tool
+list, inputSchema, and returned capability evidence can finish setup.

--- a/.agents/skills/openapi-to-setup/scripts/hash-setup-plan.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/hash-setup-plan.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const MAX_INPUT_BYTES = 256 * 1024;
+const MAX_ITEMS = 100;
+const SENSITIVE_KEYS = new Set([
+	"token",
+	"authorization",
+	"cookie",
+	"secret",
+	"password",
+	"headers",
+	"env",
+]);
+const PATH_KEYS = new Set(["file", "path", "target", "expectedwrites"]);
+const MODES = new Set(["analysis-only", "read-only", "write-enabled"]);
+const PACKAGE_MANAGERS = new Set(["pnpm", "npm", "yarn", "bun", "unknown", "conflict"]);
+const ACTION_KINDS = new Set([
+	"run-command",
+	"create-file",
+	"append-file",
+	"update-gitignore",
+	"manual-review",
+]);
+const PLAN_KEYS = new Set([
+	"schemaVersion",
+	"mode",
+	"observedStateHash",
+	"packageManager",
+	"actions",
+	"verification",
+	"restartRequired",
+]);
+const ACTION_KEYS = new Map([
+	["run-command", new Set(["kind", "command", "args", "network", "expectedWrites", "package", "version"])],
+	["create-file", new Set(["kind", "path", "content", "sha256"])],
+	["append-file", new Set(["kind", "path", "content", "sha256"])],
+	["update-gitignore", new Set(["kind", "path", "rule", "sha256"])],
+	["manual-review", new Set(["kind", "reason"])],
+]);
+
+function fail(message) {
+	throw new Error(message);
+}
+
+function stable(value) {
+	if (Array.isArray(value)) return value.map(stable);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.keys(value)
+				.sort()
+				.map((key) => [key, stable(value[key])]),
+		);
+	}
+	return value;
+}
+
+function safeRelativePath(value, context) {
+	if (typeof value !== "string" || value.length === 0 || value.length > 512) fail(`${context} must be a bounded relative path.`);
+	if (
+		path.posix.isAbsolute(value) ||
+		path.win32.isAbsolute(value) ||
+		/^[A-Za-z]:/.test(value) ||
+		value.startsWith("\\\\") ||
+		value.includes("\0")
+	) fail(`${context} must not be absolute.`);
+	const segments = value.replaceAll("\\", "/").split("/");
+	if (segments.some((segment) => segment === ".." || segment === "")) fail(`${context} must stay inside the project root.`);
+}
+
+function isEscapingPath(value) {
+	const segments = value.replaceAll("\\", "/").split("/");
+	return segments.some((segment) => segment === "..");
+}
+
+function inspectValue(value, context = "plan", seen = new Set()) {
+	if (value === null || typeof value === "string" || typeof value === "boolean" || typeof value === "number") {
+		if (typeof value === "number" && !Number.isFinite(value)) fail(`${context} contains a non-finite number.`);
+		return;
+	}
+	if (typeof value !== "object") fail(`${context} contains an unsupported value.`);
+	if (seen.has(value)) fail(`${context} contains a cycle.`);
+	seen.add(value);
+	if (Array.isArray(value)) {
+		if (value.length > MAX_ITEMS) fail(`${context} contains too many items.`);
+		for (const [index, item] of value.entries()) inspectValue(item, `${context}[${index}]`, seen);
+		seen.delete(value);
+		return;
+	}
+	for (const [key, child] of Object.entries(value)) {
+		const normalizedKey = key.toLowerCase();
+		if (SENSITIVE_KEYS.has(normalizedKey)) fail(`${context} contains forbidden sensitive field ${key}.`);
+		if (PATH_KEYS.has(normalizedKey)) {
+			const paths = Array.isArray(child) ? child : [child];
+			for (const [index, candidate] of paths.entries()) safeRelativePath(candidate, `${context}.${key}[${index}]`);
+		}
+		inspectValue(child, `${context}.${key}`, seen);
+	}
+	seen.delete(value);
+}
+
+function validatePlan(plan) {
+	if (!plan || typeof plan !== "object" || Array.isArray(plan)) fail("Setup Plan must be a JSON object.");
+	inspectValue(plan);
+	for (const key of Object.keys(plan)) {
+		if (!PLAN_KEYS.has(key)) fail(`Setup Plan contains unsupported field ${key}.`);
+	}
+	if (plan.schemaVersion !== 1) fail("schemaVersion must equal 1.");
+	if (!MODES.has(plan.mode)) fail("mode must be analysis-only, read-only, or write-enabled.");
+	if (typeof plan.observedStateHash !== "string" || !/^[a-f0-9]{64}$/.test(plan.observedStateHash)) {
+		fail("observedStateHash must be a lowercase SHA-256 value.");
+	}
+	if (!PACKAGE_MANAGERS.has(plan.packageManager)) fail("packageManager is invalid.");
+	if (!Array.isArray(plan.actions) || plan.actions.length > MAX_ITEMS) fail("actions must be a bounded array.");
+	if (
+		!Array.isArray(plan.verification) ||
+		plan.verification.length > MAX_ITEMS ||
+		plan.verification.some((item) => typeof item !== "string" || item.length === 0 || item.length > 1024)
+	) fail("verification must be a bounded string array.");
+	if (typeof plan.restartRequired !== "boolean") fail("restartRequired must be boolean.");
+	for (const [index, action] of plan.actions.entries()) {
+		if (!action || typeof action !== "object" || Array.isArray(action) || !ACTION_KINDS.has(action.kind)) {
+			fail(`actions[${index}] has an unsupported kind.`);
+		}
+		for (const key of Object.keys(action)) {
+			if (!ACTION_KEYS.get(action.kind).has(key)) fail(`actions[${index}] contains unsupported field ${key}.`);
+		}
+		if (action.kind === "run-command") {
+			if (typeof action.command !== "string" || !/^[A-Za-z0-9._-]+$/.test(action.command)) {
+				fail(`actions[${index}].command must be a program name, not a shell expression.`);
+			}
+			if (!Array.isArray(action.args) || action.args.some((arg) => typeof arg !== "string" || arg.length > 1024 || arg.includes("\0"))) {
+				fail(`actions[${index}].args must be a bounded argv array.`);
+			}
+			for (const [argIndex, arg] of action.args.entries()) {
+				if (path.posix.isAbsolute(arg) || path.win32.isAbsolute(arg) || /^[A-Za-z]:/.test(arg) || arg.startsWith("\\\\") || isEscapingPath(arg)) {
+					fail(`actions[${index}].args[${argIndex}] must not contain an absolute or escaping target path.`);
+				}
+			}
+			if (typeof action.network !== "boolean") fail(`actions[${index}].network must be boolean.`);
+			if (!Array.isArray(action.expectedWrites) || action.expectedWrites.length > MAX_ITEMS) {
+				fail(`actions[${index}].expectedWrites must be a bounded path array.`);
+			}
+			for (const field of ["package", "version"]) {
+				if (action[field] !== undefined && (typeof action[field] !== "string" || action[field].length === 0 || action[field].length > 256)) {
+					fail(`actions[${index}].${field} must be a bounded string.`);
+				}
+			}
+		} else if (["create-file", "append-file"].includes(action.kind)) {
+			if (typeof action.path !== "string" || typeof action.content !== "string" || action.content.length > MAX_INPUT_BYTES) {
+				fail(`actions[${index}] must contain a bounded path and content.`);
+			}
+		} else if (action.kind === "update-gitignore") {
+			if (typeof action.path !== "string" || typeof action.rule !== "string" || action.rule.length === 0 || action.rule.length > 512) {
+				fail(`actions[${index}] must contain a bounded path and ignore rule.`);
+			}
+		} else if (typeof action.reason !== "string" || action.reason.length === 0 || action.reason.length > 1024) {
+			fail(`actions[${index}].reason must be a bounded string.`);
+		}
+		if (action.sha256 !== undefined && (typeof action.sha256 !== "string" || !/^[a-f0-9]{64}$/.test(action.sha256))) {
+			fail(`actions[${index}].sha256 must be a lowercase SHA-256 value.`);
+		}
+	}
+}
+
+async function readStdin() {
+	const chunks = [];
+	let size = 0;
+	for await (const chunk of process.stdin) {
+		size += chunk.length;
+		if (size > MAX_INPUT_BYTES) fail("Setup Plan exceeds the input size limit.");
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks).toString("utf8");
+}
+
+async function readInput(argv) {
+	if (argv.length === 0) return readStdin();
+	if (argv.length !== 2 || argv[0] !== "--file") fail("Usage: hash-setup-plan.mjs [--file <plan.json>]");
+	const info = await readFile(argv[1]);
+	if (info.length > MAX_INPUT_BYTES) fail("Setup Plan exceeds the input size limit.");
+	return info.toString("utf8");
+}
+
+try {
+	const source = await readInput(process.argv.slice(2));
+	let plan;
+	try {
+		plan = JSON.parse(source);
+	} catch {
+		fail("Setup Plan must be valid JSON.");
+	}
+	validatePlan(plan);
+	const canonicalJson = JSON.stringify(stable(plan));
+	const setupPlanId = createHash("sha256").update(canonicalJson).digest("hex");
+	process.stdout.write(`${JSON.stringify({ schemaVersion: 1, setupPlanId, canonicalJson })}\n`);
+} catch (error) {
+	process.stderr.write(`openapi-to setup plan rejected: ${error?.message ?? "unknown error"}\n`);
+	process.exitCode = 1;
+}

--- a/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const SCHEMA_VERSION = 1;
+const MAX_FILE_BYTES = 128 * 1024;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const MAX_DEPENDENCY_RESULTS = 100;
+const SUPPORTED_CONFIG_FILES = [
+	"openapi.config.ts",
+	"openapi.config.js",
+	"openapi.config.cjs",
+	"openapi.config.mjs",
+];
+const LOCK_FILES = new Map([
+	["pnpm-lock.yaml", "pnpm"],
+	["package-lock.json", "npm"],
+	["npm-shrinkwrap.json", "npm"],
+	["yarn.lock", "yarn"],
+	["bun.lock", "bun"],
+	["bun.lockb", "bun"],
+]);
+const DEPENDENCY_SECTIONS = [
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+	"optionalDependencies",
+];
+
+function sha256(value) {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function stable(value) {
+	if (Array.isArray(value)) return value.map(stable);
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.keys(value)
+				.sort()
+				.map((key) => [key, stable(value[key])]),
+		);
+	}
+	return value;
+}
+
+function canonicalJson(value) {
+	return JSON.stringify(stable(value));
+}
+
+function isInside(root, candidate) {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+async function entryInfo(root, relativePath) {
+	const candidate = path.resolve(root, relativePath);
+	if (!isInside(root, candidate)) return { exists: false, unsafe: true };
+	try {
+		const entry = await lstat(candidate);
+		const resolved = await realpath(candidate);
+		if (!isInside(root, resolved)) {
+			return { exists: true, unsafe: true, symlink: entry.isSymbolicLink() };
+		}
+		return {
+			exists: true,
+			unsafe: entry.isSymbolicLink(),
+			symlink: entry.isSymbolicLink(),
+			isFile: entry.isFile(),
+			isDirectory: entry.isDirectory(),
+			size: entry.size,
+			path: candidate,
+		};
+	} catch (error) {
+		if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+			return { exists: false, unsafe: false };
+		}
+		if (error?.code === "ELOOP") return { exists: true, unsafe: true, symlink: true };
+		throw error;
+	}
+}
+
+async function readBoundedText(root, relativePath) {
+	const info = await entryInfo(root, relativePath);
+	if (!info.exists || info.unsafe || !info.isFile) return { info };
+	let handle;
+	try {
+		handle = await open(info.path, constants.O_RDONLY | constants.O_NOFOLLOW);
+		const opened = await handle.stat();
+		if (!opened.isFile()) return { info: { ...info, unsafe: true } };
+		if (opened.size > MAX_FILE_BYTES) return { info, tooLarge: true };
+		return { info, text: await handle.readFile("utf8") };
+	} catch (error) {
+		if (error?.code === "ELOOP") return { info: { ...info, unsafe: true } };
+		throw error;
+	} finally {
+		await handle?.close();
+	}
+}
+
+function packageManagerName(value) {
+	if (typeof value !== "string") return undefined;
+	const match = value.match(/^(pnpm|npm|yarn|bun)(?:@|$)/);
+	return match?.[1];
+}
+
+function exactVersion(value) {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.replace(/^workspace:/, "").replace(/^npm:/, "");
+	return /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(normalized)
+		? normalized.replace(/^v/, "")
+		: undefined;
+}
+
+function collectDependencies(manifest) {
+	const packages = [];
+	for (const section of DEPENDENCY_SECTIONS) {
+		const values = manifest?.[section];
+		if (!values || typeof values !== "object" || Array.isArray(values)) continue;
+		for (const name of Object.keys(values).sort()) {
+			if (name !== "openapi-to" && !name.startsWith("@openapi-to/")) continue;
+			const range = typeof values[name] === "string" ? values[name] : "invalid";
+			packages.push({
+				name,
+				section,
+				range,
+				aggregate: name === "openapi-to",
+				mcpOnly: name === "@openapi-to/mcp",
+			});
+		}
+	}
+	const exactVersions = new Set(packages.map(({ range }) => exactVersion(range)).filter(Boolean));
+	return {
+		aggregate: packages.find(({ aggregate }) => aggregate) ?? null,
+		mcpOnly: packages.find(({ mcpOnly }) => mcpOnly) ?? null,
+		packages: packages.slice(0, MAX_DEPENDENCY_RESULTS),
+		total: packages.length,
+		omitted: Math.max(0, packages.length - MAX_DEPENDENCY_RESULTS),
+		versionConflict: exactVersions.size > 1,
+	};
+}
+
+function gitignoreStatus(text) {
+	if (typeof text !== "string") return { ignored: false, evidence: "missing" };
+	let ignored = false;
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith("#")) continue;
+		if ([".openapi-to", ".openapi-to/", "/.openapi-to", "/.openapi-to/"].includes(line)) ignored = true;
+		if (line.startsWith("!.openapi-to") || line.startsWith("!/.openapi-to")) ignored = false;
+	}
+	return { ignored, evidence: ignored ? "explicit-root-rule" : "not-detected" };
+}
+
+function tomlSections(text) {
+	const sections = [];
+	for (const match of text.matchAll(/^\s*\[([^\]\r\n]+)]\s*(?:#.*)?$/gm)) {
+		sections.push({ name: match[1].trim(), start: match.index, end: text.length });
+	}
+	for (let index = 0; index < sections.length - 1; index += 1) sections[index].end = sections[index + 1].start;
+	return sections;
+}
+
+function inspectCodexToml(text) {
+	const sections = tomlSections(text);
+	const serverSections = sections.filter(({ name }) => name === "mcp_servers.openapi_to");
+	const applySections = sections.filter(({ name }) => name === "mcp_servers.openapi_to.tools.openapi_apply_generation");
+	const serverText = serverSections.map(({ start, end }) => text.slice(start, end)).join("\n");
+	const applyText = applySections.map(({ start, end }) => text.slice(start, end)).join("\n");
+	const quotedValues = [...serverText.matchAll(/["']([^"'\r\n]*)["']/g)].map((match) => match[1]);
+	const absolutePathDetected = quotedValues.some((value) => {
+		const nativeCmdFlag = ["/d", "/s", "/c"].includes(value.toLowerCase());
+		if ((!nativeCmdFlag && value.startsWith("/")) || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\") || value.startsWith("//")) return true;
+		return /(?:^|\s)[A-Za-z]:[\\/]/.test(value) || /(?:^|\s)\\\\[^\s]/.test(value) || /(?:^|\s)\/[^\s/]+\//.test(value);
+	});
+	const hasFlag = (flag) => quotedValues.some((value) => new RegExp(`(?:^|\\s)${flag.replaceAll("-", "\\-")}(?:\\s|$)`).test(value));
+	const allowWrite = hasFlag("--allow-write");
+	const hasConfig = hasFlag("--config");
+	const applyPrompt = /\bapproval_mode\s*=\s*["']prompt["']/.test(applyText);
+	let inferredMode = "unknown";
+	if (serverSections.length === 0 && /\bopenapi_to\b/.test(text)) inferredMode = "unknown";
+	else if (serverSections.length === 0) inferredMode = "missing";
+	else if (serverSections.length > 1) inferredMode = "unknown";
+	else if (allowWrite && applyPrompt) inferredMode = "write-enabled";
+	else if (allowWrite) inferredMode = "unknown";
+	else if (hasConfig) inferredMode = "read-only";
+	else inferredMode = "analysis-only";
+	const configurationBlocked =
+		(serverSections.length === 0 && /\bopenapi_to\b/.test(text)) ||
+		serverSections.length > 1 ||
+		(allowWrite && !applyPrompt) ||
+		absolutePathDetected ||
+		applySections.length > 1;
+	return {
+		serverSectionCount: serverSections.length,
+		applyPromptSectionCount: applySections.length,
+		applyPromptDetected: applyPrompt,
+		absolutePathDetected,
+		inferredMode,
+		manualReviewRequired: serverSections.length > 0 || configurationBlocked,
+		configurationBlocked,
+		parser: "conservative-text-inspection",
+	};
+}
+
+async function inspect(rootArgument) {
+	const root = await realpath(path.resolve(rootArgument));
+	const blockingReasons = [];
+	const nodeMajor = Number(process.versions.node.split(".")[0]);
+	if (nodeMajor < 20) blockingReasons.push("NODE_VERSION_UNSUPPORTED");
+	const packageRead = await readBoundedText(root, "package.json");
+	let manifest;
+	let packageJsonValid = false;
+	if (packageRead.info.unsafe) blockingReasons.push("PACKAGE_JSON_OUTSIDE_ROOT");
+	else if (packageRead.tooLarge) blockingReasons.push("PACKAGE_JSON_TOO_LARGE");
+	else if (packageRead.text !== undefined) {
+		try {
+			manifest = JSON.parse(packageRead.text);
+			packageJsonValid = Boolean(manifest && typeof manifest === "object" && !Array.isArray(manifest));
+			if (!packageJsonValid) blockingReasons.push("PACKAGE_JSON_INVALID");
+		} catch {
+			blockingReasons.push("PACKAGE_JSON_INVALID");
+		}
+	}
+
+	const hasDeclaredManager = Boolean(manifest && Object.hasOwn(manifest, "packageManager"));
+	const declaredManager = packageManagerName(manifest?.packageManager);
+	const lockFiles = [];
+	for (const [file, manager] of LOCK_FILES) {
+		const info = await entryInfo(root, file);
+		if (info.unsafe) blockingReasons.push("LOCKFILE_OUTSIDE_ROOT");
+		if (info.exists && !info.unsafe) lockFiles.push({ file, manager });
+	}
+	const lockManagers = [...new Set(lockFiles.map(({ manager }) => manager))].sort();
+	let detectedManager = "unknown";
+	let managerEvidence = "none";
+	if (hasDeclaredManager && !declaredManager) {
+		detectedManager = "unknown";
+		managerEvidence = "unrecognized-packageManager";
+		blockingReasons.push("PACKAGE_MANAGER_UNKNOWN");
+	} else if (declaredManager) {
+		detectedManager = declaredManager;
+		managerEvidence = "packageManager";
+	} else if (!hasDeclaredManager && lockManagers.length === 1) {
+		detectedManager = lockManagers[0];
+		managerEvidence = "unique-lockfile-manager";
+	}
+	if (lockManagers.length > 1 || (declaredManager && lockManagers.some((value) => value !== declaredManager))) {
+		detectedManager = "conflict";
+		managerEvidence = "conflicting-evidence";
+		blockingReasons.push("PACKAGE_MANAGER_CONFLICT");
+	}
+
+	const dependencies = collectDependencies(manifest);
+	if (dependencies.versionConflict) blockingReasons.push("OPENAPI_TO_VERSION_CONFLICT");
+	const configFiles = [];
+	for (const file of SUPPORTED_CONFIG_FILES) {
+		const read = await readBoundedText(root, file);
+		if (read.info.unsafe) {
+			blockingReasons.push("GENERATION_CONFIG_OUTSIDE_ROOT");
+			continue;
+		}
+		if (!read.info.exists) continue;
+		if (read.tooLarge) {
+			blockingReasons.push("GENERATION_CONFIG_TOO_LARGE");
+			configFiles.push({ path: file, sha256: null });
+		} else if (read.text !== undefined) configFiles.push({ path: file, sha256: sha256(read.text) });
+	}
+	if (configFiles.length > 1) blockingReasons.push("MULTIPLE_GENERATION_CONFIGS");
+
+	const stateDirectory = await entryInfo(root, ".openapi-to");
+	if (stateDirectory.unsafe) blockingReasons.push("STATE_DIRECTORY_OUTSIDE_ROOT");
+	const gitignoreRead = await readBoundedText(root, ".gitignore");
+	if (gitignoreRead.info.unsafe) blockingReasons.push("GITIGNORE_OUTSIDE_ROOT");
+	if (gitignoreRead.tooLarge) blockingReasons.push("GITIGNORE_TOO_LARGE");
+	const ignore = gitignoreStatus(gitignoreRead.text);
+	const codexRead = await readBoundedText(root, ".codex/config.toml");
+	if (codexRead.info.unsafe) blockingReasons.push("CODEX_CONFIG_OUTSIDE_ROOT");
+	if (codexRead.tooLarge) blockingReasons.push("CODEX_CONFIG_TOO_LARGE");
+	const codexInspection = codexRead.text === undefined ? null : inspectCodexToml(codexRead.text);
+	if (codexInspection?.serverSectionCount > 1) blockingReasons.push("DUPLICATE_CODEX_SERVER_SECTION");
+	if (codexInspection?.configurationBlocked) blockingReasons.push("CODEX_CONFIG_MANUAL_REVIEW_REQUIRED");
+	const gitEntry = await entryInfo(root, ".git");
+	if (gitEntry.unsafe) blockingReasons.push("GIT_METADATA_OUTSIDE_ROOT");
+
+	let state = "PACKAGE_READY";
+	if (blockingReasons.length > 0) state = "BLOCKED";
+	else if (!dependencies.aggregate) state = "PACKAGE_MISSING";
+	else if (configFiles.length === 0) state = "CONFIG_MISSING";
+	else if (!codexInspection || codexInspection.serverSectionCount === 0) state = "HOST_CONFIG_MISSING";
+	else state = "HOST_CONFIG_READY";
+
+	const observation = {
+		schemaVersion: SCHEMA_VERSION,
+		state,
+		blockingReasons: [...new Set(blockingReasons)].sort(),
+		workspace: {
+			root: ".",
+			packageJson: { exists: packageRead.info.exists === true, valid: packageJsonValid },
+			node: { major: nodeMajor, supported: nodeMajor >= 20 },
+			gitRepository: gitEntry.exists === true && !gitEntry.unsafe,
+		},
+		packageManager: {
+			value: detectedManager,
+			evidence: managerEvidence,
+			declared: declaredManager ?? null,
+			lockFiles,
+			automaticInstallSupported: detectedManager === "pnpm",
+		},
+		dependencies,
+		generationConfig: {
+			status: configFiles.length === 0 ? "missing" : configFiles.length === 1 ? "ready" : "multiple",
+			supportedFileNames: SUPPORTED_CONFIG_FILES,
+			files: configFiles,
+		},
+		runtimeState: {
+			directoryPresent: stateDirectory.exists === true && !stateDirectory.unsafe,
+			gitignorePresent: gitignoreRead.info.exists === true && !gitignoreRead.info.unsafe,
+			ignored: ignore.ignored,
+			ignoreEvidence: ignore.evidence,
+		},
+		codex: {
+			configPresent: codexRead.info.exists === true && !codexRead.info.unsafe,
+			sha256: codexRead.text === undefined ? null : sha256(codexRead.text),
+			...(codexInspection ?? {
+				serverSectionCount: 0,
+				applyPromptSectionCount: 0,
+				applyPromptDetected: false,
+				absolutePathDetected: false,
+				inferredMode: "missing",
+				manualReviewRequired: false,
+				configurationBlocked: false,
+				parser: "conservative-text-inspection",
+			}),
+		},
+	};
+	return { ...observation, observedStateHash: sha256(canonicalJson(observation)) };
+}
+
+function parseArguments(argv) {
+	let root = process.cwd();
+	for (let index = 0; index < argv.length; index += 1) {
+		if (argv[index] !== "--root" || index + 1 >= argv.length) throw new Error("Usage: inspect-project.mjs [--root <path>]");
+		root = argv[index + 1];
+		index += 1;
+	}
+	return root;
+}
+
+try {
+	const result = await inspect(parseArguments(process.argv.slice(2)));
+	const output = `${JSON.stringify(result)}\n`;
+	if (Buffer.byteLength(output) > MAX_OUTPUT_BYTES) throw new Error("Inspection output exceeded its size limit.");
+	process.stdout.write(output);
+} catch (error) {
+	process.stderr.write(`openapi-to setup inspection failed: ${error?.message ?? "unknown error"}\n`);
+	process.exitCode = 1;
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ explicitly names a specialized primary.
 | --- | --- |
 | Feature, bug fix, refactor, CI/config/documentation change | Primary: `.agents/skills/implement-and-review/SKILL.md` |
 | Implement a backend-API-dependent feature in an openapi-to consuming project | Specialized primary: `.agents/skills/openapi-to-generate/SKILL.md` |
+| Install, configure, diagnose, or validate openapi-to in a consuming project | Specialized primary: `.agents/skills/openapi-to-setup/SKILL.md` |
 | Add or substantially change a CLI command | Support: `.agents/skills/add-cli-command/SKILL.md` |
 | Add or substantially change a read-only MCP Tool | Support: `.agents/skills/add-mcp-tool/SKILL.md` |
 | Change the MCP Prepare/Apply writer | Support: `.agents/skills/add-mcp-write-tool/SKILL.md` |

--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@ The current version is not compatible with V2.[V2 document](https://github.com/V
 
 `openapi-to` is a TypeScript compiler, CLI, generator toolkit, and local stdio MCP server for Swagger/OpenAPI documents. The published aggregate includes TypeScript type and request generation, Zod schemas, SWR hooks, Vue Query hooks, MSW handlers, and the MCP runtime. Faker, NestJS, and React Query generators are not shipped.
 
-See the single [capability matrix](docs/capability-matrix.md) for exact package, dialect, CLI, and MCP status. Start with the [getting-started guide](docs/getting-started.md); local AI Host setup is documented for [Codex](docs/codex-mcp.md), [Claude Code](docs/ai-hosts/claude-code.md), [Cursor](docs/ai-hosts/cursor.md), and [generic stdio Hosts](docs/ai-hosts/generic-stdio.md). The first-stage [consumer Agent Skill](docs/skills.md) adds a safe Operation-discovery, selective-generation, and integration workflow on top of MCP.
+See the single [capability matrix](docs/capability-matrix.md) for exact package, dialect, CLI, and MCP status. Start with the [getting-started guide](docs/getting-started.md); local AI Host setup is documented for [Codex](docs/codex-mcp.md), [Claude Code](docs/ai-hosts/claude-code.md), [Cursor](docs/ai-hosts/cursor.md), and [generic stdio Hosts](docs/ai-hosts/generic-stdio.md). The [consumer Agent Skills](docs/skills.md) provide setup/diagnosis plus safe Operation-discovery, selective-generation, and integration workflows on top of MCP.
 
-That Skill uses the consuming project's local `openapi-to` installation and
+`openapi-to-setup` is the second phase: it diagnoses package, config, ignore,
+and Codex MCP state, defaults ambiguous requests to read-only, and binds every
+write to an exact Setup Plan. It uses the existing `openapi init`, does not
+upgrade an existing version, returns `RESTART_REQUIRED` after Host changes,
+and verifies actual Tools and inputSchema after restart. See the
+[setup Skill guide](docs/setup-skill.md).
+
+The first-phase `openapi-to-generate` Skill uses the consuming project's local `openapi-to` installation and
 checks both the actual MCP Tool list and current Tool inputSchema. Matching Tool
 names can expose different capabilities across versions: operation-scoped Dry
 Run requires one explicit Target, and selection `replace` is used only when the
-current Schema explicitly supports it. The Skill does not install dependencies,
+current Schema explicitly supports it. The generation Skill does not install dependencies,
 edit project or Host configuration, replace MCP, or fall back to full-target
 generation when selective generation is unavailable.
 

--- a/docs/agents/agents-and-skills-architecture.md
+++ b/docs/agents/agents-and-skills-architecture.md
@@ -19,8 +19,10 @@ their complete architecture.
 Use one primary workflow for a task. General repository changes use
 `implement-and-review`; domain Skills assist it. Existing Actions failures and
 release preparation use their specialized primary Skills. Consumer projects
-use `openapi-to-generate` for API-dependent feature delivery through the local
-openapi-to MCP. Pure analysis does not load a write-oriented workflow.
+use `openapi-to-setup` for installation/configuration diagnosis and
+approval-bound setup, then `openapi-to-generate` for API-dependent feature
+delivery through the local openapi-to MCP. Pure analysis does not load a
+write-oriented workflow.
 
 ## Rule discovery boundary
 
@@ -129,6 +131,7 @@ workflow lifecycle.
 | --- | --- | --- |
 | `implement-and-review` | An authorized feature, bug fix, refactor, CI/configuration change, documentation change, or cross-file implementation needing validation and review closure | Added as the only general primary. Defines discovery, classification, scope lock, implementation, focused validation, full diff review, P0/P1/P2 grading, a three-round repair limit, completion gate, and fresh Git reporting. Excludes pure/read-only and specialized release/review-comment work. |
 | `openapi-to-generate` | A backend-API-dependent feature in an openapi-to consuming project that requires Operation discovery, bounded contract reading, selective generation, controlled Prepare/Apply, and business-code integration | Added as a specialized consumer primary. It uses the consuming project's local dependency and actual MCP Tool list, prefers operation-scoped generation, requires exact-plan approval, and excludes this Monorepo's implementation, pure frontend work, setup automation, publication, and approval bypass. |
+| `openapi-to-setup` | Installation, root config initialization, Codex MCP configuration, or setup diagnosis in an openapi-to consuming project | Added as the phase-two specialized consumer primary. It diagnoses read-only first, defaults to read-only mode, binds every write to an exact Setup Plan, stops for Host restart, validates actual Tools/Schemas, and hands business generation to `openapi-to-generate`. |
 | `fix-github-actions` | An existing failed Actions check or suspected workflow regression | Retained as a specialized primary. It owns run/log evidence and failure classification, not general product refactors, workflow redesign, release, or unauthorized reruns. |
 | `release-monorepo` | Release planning or publication-readiness verification | Retained as a specialized primary. It prepares evidence and a plan; publication, push, and tags still require exact authorization. |
 
@@ -149,7 +152,7 @@ workflow lifecycle.
 | --- | --- | --- |
 | `run-codegen-tests` | Validate a change that may alter generated output or decide whether a fixture/snapshot change is correct | Retained as a helper. It validates output and idempotency but does not diagnose or implement the owning fix. |
 
-All eleven Skills have a unique directory-matching name, specific positive and
+All twelve Skills have a unique directory-matching name, specific positive and
 negative triggers, a required `agents/openai.yaml`, explicit inputs or
 preconditions, bounded modification authority, validation guidance, failure or
 stop handling, and a completion/report boundary. Domain Skills may mention
@@ -159,7 +162,7 @@ writes without user authorization.
 
 ## Contract-verified Skill roles
 
-Tracked Skill count: `11`.
+Tracked Skill count: `12`.
 
 This fixed table is the architecture document's machine-validated role
 inventory. The contract compares it with both Git-tracked Skill entrypoints and
@@ -169,6 +172,7 @@ the root routing table; Skill prose does not assign a role.
 | --- | --- |
 | `implement-and-review` | general-primary |
 | `openapi-to-generate` | specialized-primary |
+| `openapi-to-setup` | specialized-primary |
 | `fix-github-actions` | specialized-primary |
 | `release-monorepo` | specialized-primary |
 | `add-cli-command` | domain-support |
@@ -184,6 +188,7 @@ the root routing table; Skill prose does not assign a role.
 | Request | Primary | Supporting |
 | --- | --- | --- |
 | General implementation or bug fix | `implement-and-review` | Only the matching domain/validation Skill |
+| Install, configure, diagnose, or validate openapi-to in a consuming project | `openapi-to-setup` | Consuming-project rules and exact Setup Plan approval; hand API work to `openapi-to-generate` after restart verification |
 | API-dependent feature in a consuming project | `openapi-to-generate` | The consuming project's own rules and validation; no Monorepo implementation Skill |
 | CLI command/option | `implement-and-review` | `add-cli-command`; add `run-codegen-tests` only if output changes |
 | Read-only MCP Tool | `implement-and-review` | `add-mcp-tool` |

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -113,4 +113,10 @@ Once this trusted Server is available, the first-stage
 Operation discovery, operation-scoped Dry Run, exact-plan approval, Apply, and
 business integration sequence. It uses the consuming project's local
 openapi-to version, actual Tool list, and current Tool inputSchema; setup
-automation remains outside this stage.
+automation remains outside this stage. The second-stage
+[`openapi-to-setup` Skill](./setup-skill.md) owns that diagnosis and
+configuration boundary. It defaults to read-only, uses the existing
+`openapi init`, does not upgrade an existing version, requires an exact Setup
+Plan ID for writes, and returns `RESTART_REQUIRED` after changing this file.
+After restart it treats 3/8/10 only as orientation and verifies the actual Tool
+list, current Tool inputSchema, and returned capability fields.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,8 +81,16 @@ Choose the Host-specific configuration:
 
 All Hosts share the same [security boundary](./mcp-security.md) and [troubleshooting guide](./troubleshooting.md).
 
-After installing and configuring MCP, a compatible AI Host can use the
-first-stage [`openapi-to-generate` consumer Skill](./skills.md) to discover
+The second-stage [`openapi-to-setup` consumer Skill](./setup-skill.md) can
+diagnose and configure an aggregate-package project and Codex MCP. It defaults
+to read-only, uses the existing `openapi init`, does not upgrade an existing
+version, and requires exact Setup Plan approval before package, init, ignore,
+or Host writes. Automatic package mutation is pnpm-only; npm, Yarn, and Bun are
+diagnostic/manual in this phase. A Codex config write returns
+`RESTART_REQUIRED` until restart and actual Tool/inputSchema verification.
+
+After setup, a compatible AI Host can use the first-stage
+[`openapi-to-generate` consumer Skill](./skills.md) to discover
 Operations, preview operation-scoped output, preserve the Prepare/Apply
 approval boundary, and integrate generated code. The Skill orchestrates MCP;
 it does not replace the Server or perform initial package, generation-config,

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -1,0 +1,71 @@
+# openapi-to setup Skill
+
+`openapi-to-setup` is the second consumer Agent Skills phase. It diagnoses and
+configures openapi-to in a consuming project; it does not replace the local MCP
+Server. The first-phase `openapi-to-generate` Skill starts only after setup and
+handles API Operation discovery, selective generation, and business-code
+integration.
+
+Use setup for package installation, the existing `openapi init` flow,
+`/.openapi-to/` ignore repair, Codex project MCP configuration, startup
+diagnosis, and 3/8/10 Tool-mode validation. A vague setup request defaults to
+`read-only`. `write-enabled` is explicit and retains prompt approval for
+`openapi_apply_generation`.
+
+## Diagnose before changing anything
+
+The Skill's standard-library inspector reads bounded project metadata without
+executing `openapi.config.*`, walking generated/state directories, inspecting
+global packages, accessing the network, or returning configuration bodies and
+credentials. The workflow keeps local package declaration, one supported
+config, local command resolution, Host configuration, Host restart, Server
+connection, and verified Tool capability as distinct evidence.
+
+Supported root configs are `openapi.config.ts`, `.js`, `.cjs`, and `.mjs`.
+Multiple candidates block setup. `.openapi-to/` is runtime state; the retired
+`.OpenAPI` config location is not used.
+
+## Approval-bound writes
+
+Every package install, initializer run, ignore change, and Codex config change
+requires a complete JSON Setup Plan bound to the current inspector state hash.
+The plan shows exact argv, network use, expected writes, direct file diffs,
+verification, and restart impact. Its canonical SHA-256 `setupPlanId` must be
+named in explicit user approval. If the manifest, lockfile, config, ignore file,
+Codex file, or overlapping Git state changes, the Skill discards the approval
+and creates a new plan.
+
+The Skill never uses a global install and does not upgrade an existing
+openapi-to version. Installation requires an exact version: explicit user
+choice first, then a consistent exact local `@openapi-to/*` version, otherwise a
+new version decision. It uses the aggregate package, not `@openapi-to/mcp` as a
+business-environment substitute.
+
+Automatic package writes are currently pnpm-only:
+
+```sh
+pnpm add -D --save-exact openapi-to@<exact-version>
+```
+
+npm, Yarn, and Bun are diagnosed but their install/config mutation remains
+manual in this phase. Host automation is Codex-first; Claude Code, Cursor, and
+generic stdio Hosts continue to use their existing manual guides.
+
+## Codex restart and verification
+
+The Skill may create a missing trusted project `.codex/config.toml` or append
+one absent `openapi_to` section after exact approval. It preserves existing
+bytes and unknown sections. An existing `openapi_to` section, duplicate section,
+absolute path, or unrecognized TOML shape requires manual review; the Skill
+does not implement a general TOML rewriter.
+
+After a Codex config change, setup returns `RESTART_REQUIRED`. Only after the
+user restarts Codex does the Skill inspect the actual Tool list, relevant Tool
+inputSchema, and returned capability fields. Counts of 3, 8, and 10 are useful
+orientation for analysis-only, read-only, and controlled-write modes, but a
+matching count alone is not capability evidence.
+
+Once the requested state is verified, use `openapi-to-generate`: read-only setup
+supports discovery and preview; write-enabled setup supports its separately
+approved Prepare/Apply workflow. Setup never performs that business generation
+workflow or bypasses Apply approval.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -6,9 +6,14 @@ Prepare/Apply capabilities. A Skill supplies the calling order, scope choices,
 approval boundary, business-code integration steps, and failure handling used
 by an AI Host.
 
-## First-stage Skill
+## Two consumer phases
 
-The first stage ships one consumer workflow:
+The repository ships two specialized consuming-project workflows:
+
+- [`openapi-to-setup`](../.agents/skills/openapi-to-setup/SKILL.md) diagnoses
+  package, config, ignore, local command, Codex project configuration, restart,
+  and actual Tool capability. It defaults ambiguous setup requests to
+  read-only and requires exact Setup Plan approval for every write.
 
 - [`openapi-to-generate`](../.agents/skills/openapi-to-generate/SKILL.md) finds
   the API Operations needed by a business feature, reads bounded contracts,
@@ -16,19 +21,22 @@ The first stage ships one consumer workflow:
   approval of its current `planHash`, applies that plan, and integrates the
   generated code into the consuming project.
 
-Use it for requests such as “add user deletion from the API documentation”,
+Use setup for “configure openapi-to in this project”, “why are only three Tools
+visible?”, or “enable controlled writes”. Use generate for requests such as
+“add user deletion from the API documentation”,
 “find the order export endpoint and generate its request code”, or “implement
 this page's API call with openapi-to”. Do not use it for pure frontend work or
 for changing this Monorepo's MCP, CLI, Core, plugins, or release process.
 
-The repository keeps one authoritative Skill source under
-`.agents/skills/openapi-to-generate/`. Point a compatible Agent Skills installer
-at this repository and select `openapi-to-generate`; do not copy or maintain a
-second source tree inside this repository. The Skill interface metadata lives
-beside it in `agents/openai.yaml`. The canonical GitHub directory is:
+The repository keeps one authoritative source per Skill under `.agents/skills/`.
+Point a compatible Agent Skills installer at this repository and select
+`openapi-to-setup` or `openapi-to-generate`; do not copy or maintain a second
+source tree inside this repository. Interface metadata lives beside each Skill
+in `agents/openai.yaml`. The canonical GitHub directories are:
 
 ```text
 https://github.com/Vc-great/openapi-to/tree/main/.agents/skills/openapi-to-generate
+https://github.com/Vc-great/openapi-to/tree/main/.agents/skills/openapi-to-setup
 ```
 
 Installer commands and discovery behavior vary by Agent Host. Use a compatible
@@ -100,9 +108,16 @@ configuration, then configure the trusted local Server with the
 
 ## Phase boundary
 
-This first stage provides workflow guidance and repository contract validation
-only; it does not change MCP runtime behavior. The Skill never automatically
-installs dependencies or modifies `package.json`,
-`openapi.config.ts`, or `.codex/config.toml`. A future `openapi-to-setup` Skill
-may address installation and Host configuration. This stage does not add MCP
-Tools, transports, authentication, runtime behavior, or automatic Apply.
+The setup Skill is phase two. It runs read-only diagnosis first, uses the
+existing `openapi init`, does not upgrade an existing version, and supports
+automatic package mutation only for pnpm. Every installation or configuration
+change requires the exact current Setup Plan ID. Codex project configuration
+is Codex-first; npm, Yarn, and Bun plus Claude Code, Cursor, and generic Host
+writes remain diagnostic/manual boundaries. Host changes return
+`RESTART_REQUIRED`, and the actual Tool list plus current Tool inputSchema are
+verified only after restart. See [the setup guide](./setup-skill.md).
+
+The generate Skill remains phase one and never installs dependencies or
+modifies `package.json`, `openapi.config.ts`, or `.codex/config.toml`. Setup does
+not add MCP Tools or replace MCP, and it hands daily API discovery, selective
+generation, and integration to generate after the requested mode is verified.

--- a/scripts/openapi-to-setup.node-test.mjs
+++ b/scripts/openapi-to-setup.node-test.mjs
@@ -1,0 +1,315 @@
+import assert from "node:assert/strict";
+import { execFile, spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const repositoryRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const inspector = join(repositoryRoot, ".agents/skills/openapi-to-setup/scripts/inspect-project.mjs");
+const hasher = join(repositoryRoot, ".agents/skills/openapi-to-setup/scripts/hash-setup-plan.mjs");
+
+async function fixture(t, manifest = { private: true, packageManager: "pnpm@10.14.0" }) {
+	const root = await mkdtemp(join(tmpdir(), "openapi-to-setup-"));
+	t.after(() => rm(root, { recursive: true, force: true }));
+	await write(root, "package.json", `${JSON.stringify(manifest, null, 2)}\n`);
+	return root;
+}
+
+async function write(root, relativePath, contents) {
+	const target = join(root, relativePath);
+	await mkdir(dirname(target), { recursive: true });
+	await writeFile(target, contents);
+}
+
+async function inspect(root) {
+	const { stdout, stderr } = await execFileAsync(process.execPath, [inspector, "--root", root]);
+	assert.equal(stderr, "");
+	return { output: stdout, value: JSON.parse(stdout) };
+}
+
+function setupPlan(overrides = {}) {
+	return {
+		schemaVersion: 1,
+		mode: "read-only",
+		observedStateHash: "a".repeat(64),
+		packageManager: "pnpm",
+		actions: [],
+		verification: [],
+		restartRequired: true,
+		...overrides,
+	};
+}
+
+async function hash(plan) {
+	const { stdout, stderr, code } = await runWithInput(hasher, JSON.stringify(plan));
+	assert.equal(code, 0);
+	assert.equal(stderr, "");
+	return JSON.parse(stdout);
+}
+
+async function rejectHash(planOrSource, pattern) {
+	const result = await runWithInput(hasher, typeof planOrSource === "string" ? planOrSource : JSON.stringify(planOrSource));
+	assert.notEqual(result.code, 0);
+	assert.match(result.stderr, pattern);
+	assert.equal(result.stdout, "");
+}
+
+function runWithInput(script, input) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(process.execPath, [script], { stdio: ["pipe", "pipe", "pipe"] });
+		let stdout = "";
+		let stderr = "";
+		child.stdout.setEncoding("utf8");
+		child.stderr.setEncoding("utf8");
+		child.stdout.on("data", (chunk) => { stdout += chunk; });
+		child.stderr.on("data", (chunk) => { stderr += chunk; });
+		child.once("error", reject);
+		child.once("close", (code) => resolve({ code, stdout, stderr }));
+		child.stdin.end(input);
+	});
+}
+
+test("inspector reports a clean pnpm project with all setup capabilities missing", async (t) => {
+	const root = await fixture(t);
+	await write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+	const { value, output } = await inspect(root);
+	assert.equal(value.schemaVersion, 1);
+	assert.equal(value.state, "PACKAGE_MISSING");
+	assert.equal(value.packageManager.value, "pnpm");
+	assert.equal(value.packageManager.evidence, "packageManager");
+	assert.equal(value.dependencies.aggregate, null);
+	assert.equal(value.generationConfig.status, "missing");
+	assert.equal(value.runtimeState.ignored, false);
+	assert.equal(value.codex.configPresent, false);
+	assert.match(value.observedStateHash, /^[a-f0-9]{64}$/);
+	assert.ok(Buffer.byteLength(output) < 64 * 1024);
+	assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("inspector distinguishes aggregate and MCP-only dependency boundaries", async (t) => {
+	const aggregateRoot = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0" },
+	});
+	const aggregate = (await inspect(aggregateRoot)).value;
+	assert.equal(aggregate.state, "CONFIG_MISSING");
+	assert.equal(aggregate.dependencies.aggregate.name, "openapi-to");
+	assert.equal(aggregate.dependencies.mcpOnly, null);
+
+	const mcpRoot = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "@openapi-to/mcp": "4.2.0" },
+	});
+	const mcp = (await inspect(mcpRoot)).value;
+	assert.equal(mcp.state, "PACKAGE_MISSING");
+	assert.equal(mcp.dependencies.aggregate, null);
+	assert.equal(mcp.dependencies.mcpOnly.name, "@openapi-to/mcp");
+});
+
+test("inspector blocks package-manager and openapi-to version conflicts", async (t) => {
+	const managerRoot = await fixture(t);
+	await write(managerRoot, "yarn.lock", "# yarn lockfile v1\n");
+	const manager = (await inspect(managerRoot)).value;
+	assert.equal(manager.state, "BLOCKED");
+	assert.equal(manager.packageManager.value, "conflict");
+	assert.ok(manager.blockingReasons.includes("PACKAGE_MANAGER_CONFLICT"));
+
+	const locksRoot = await fixture(t, { private: true });
+	await write(locksRoot, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+	await write(locksRoot, "package-lock.json", "{}\n");
+	assert.ok((await inspect(locksRoot)).value.blockingReasons.includes("PACKAGE_MANAGER_CONFLICT"));
+
+	const versionsRoot = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0", "@openapi-to/mcp": "4.1.0" },
+	});
+	assert.ok((await inspect(versionsRoot)).value.blockingReasons.includes("OPENAPI_TO_VERSION_CONFLICT"));
+
+	const unknownRoot = await fixture(t, { private: true, packageManager: "other@1.0.0" });
+	await write(unknownRoot, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+	const unknown = (await inspect(unknownRoot)).value;
+	assert.equal(unknown.packageManager.value, "unknown");
+	assert.equal(unknown.packageManager.evidence, "unrecognized-packageManager");
+	assert.ok(unknown.blockingReasons.includes("PACKAGE_MANAGER_UNKNOWN"));
+});
+
+test("inspector hashes one supported config without executing it and blocks multiples", async (t) => {
+	const root = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0" },
+	});
+	const marker = join(root, "executed.txt");
+	const source = `await import("node:fs/promises").then((fs) => fs.writeFile(${JSON.stringify(marker)}, "bad"));\nexport default {};\n`;
+	await write(root, "openapi.config.ts", source);
+	const one = (await inspect(root)).value;
+	assert.equal(one.generationConfig.status, "ready");
+	assert.equal(one.generationConfig.files[0].path, "openapi.config.ts");
+	assert.match(one.generationConfig.files[0].sha256, /^[a-f0-9]{64}$/);
+	await assert.rejects(readFile(marker), /ENOENT/);
+
+	await write(root, "openapi.config.js", "module.exports = {};\n");
+	const multiple = (await inspect(root)).value;
+	assert.equal(multiple.state, "BLOCKED");
+	assert.equal(multiple.generationConfig.status, "multiple");
+	assert.ok(multiple.blockingReasons.includes("MULTIPLE_GENERATION_CONFIGS"));
+});
+
+test("inspector reports ignore state and conservative Codex modes without returning config bodies", async (t) => {
+	const root = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0" },
+	});
+	await write(root, "openapi.config.ts", "export default {};\n");
+	await write(root, ".gitignore", "dist/\n/.openapi-to/\n");
+	await mkdir(join(root, ".openapi-to"));
+	await write(root, ".openapi-to/private-state.json", '{"token":"state-secret"}\n');
+	await write(root, ".codex/config.toml", `[mcp_servers.other]\ncommand = "other"\n\n[mcp_servers.openapi_to]\ncommand = "pnpm"\nargs = ["exec", "openapi-to-mcp", "--workspace-root", ".", "--config", "openapi.config.ts"]\n# private-value-123\n`);
+	const { value, output } = await inspect(root);
+	assert.equal(value.runtimeState.directoryPresent, true);
+	assert.equal(value.runtimeState.ignored, true);
+	assert.equal(value.codex.serverSectionCount, 1);
+	assert.equal(value.codex.inferredMode, "read-only");
+	assert.equal(value.codex.manualReviewRequired, true);
+	assert.equal(value.codex.configurationBlocked, false);
+	assert.equal(value.state, "HOST_CONFIG_READY");
+	assert.equal(value.codex.parser, "conservative-text-inspection");
+	assert.doesNotMatch(output, /private-value-123|state-secret|command =/);
+
+	const unrelatedRoot = await fixture(t);
+	await write(unrelatedRoot, ".codex/config.toml", `[mcp_servers.other]\ncommand = "other"\n`);
+	const unrelated = (await inspect(unrelatedRoot)).value.codex;
+	assert.equal(unrelated.configPresent, true);
+	assert.equal(unrelated.serverSectionCount, 0);
+	assert.equal(unrelated.inferredMode, "missing");
+});
+
+test("inspector flags duplicate, absolute, and unsafe write-enabled Codex sections", async (t) => {
+	const root = await fixture(t);
+	await write(root, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "/usr/local/bin/pnpm"\nargs = ["exec", "openapi-to-mcp", "--config", "openapi.config.ts", "--allow-write"]\n\n[mcp_servers.openapi_to]\ncommand = "pnpm"\n`);
+	const duplicate = (await inspect(root)).value;
+	assert.equal(duplicate.state, "BLOCKED");
+	assert.equal(duplicate.codex.serverSectionCount, 2);
+	assert.equal(duplicate.codex.absolutePathDetected, true);
+	assert.equal(duplicate.codex.manualReviewRequired, true);
+
+	const promptRoot = await fixture(t);
+	await write(promptRoot, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "pnpm"\nargs = ["exec", "openapi-to-mcp", "--config", "openapi.config.ts", "--allow-write"]\n\n[mcp_servers.openapi_to.tools.openapi_apply_generation]\napproval_mode = "prompt"\n`);
+	const prompt = (await inspect(promptRoot)).value;
+	assert.equal(prompt.codex.inferredMode, "write-enabled");
+	assert.equal(prompt.codex.applyPromptDetected, true);
+	assert.equal(prompt.state, "PACKAGE_MISSING");
+
+	const unsafeWriteRoot = await fixture(t);
+	await write(unsafeWriteRoot, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "pnpm"\nargs = ["exec", "openapi-to-mcp", "--config", "openapi.config.ts", "--allow-write"]\n`);
+	const unsafeWrite = (await inspect(unsafeWriteRoot)).value;
+	assert.equal(unsafeWrite.state, "BLOCKED");
+	assert.equal(unsafeWrite.codex.configurationBlocked, true);
+	assert.ok(unsafeWrite.blockingReasons.includes("CODEX_CONFIG_MANUAL_REVIEW_REQUIRED"));
+
+	const windowsRoot = await fixture(t);
+	await write(windowsRoot, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "cmd.exe"\nargs = ["/d", "/s", "/c", "pnpm exec openapi-to-mcp --workspace-root . --config openapi.config.ts --allow-write"]\n\n[mcp_servers.openapi_to.tools.openapi_apply_generation]\napproval_mode = "prompt"\n`);
+	const windows = (await inspect(windowsRoot)).value;
+	assert.equal(windows.codex.inferredMode, "write-enabled");
+	assert.equal(windows.codex.absolutePathDetected, false);
+	assert.equal(windows.codex.configurationBlocked, false);
+	assert.equal(windows.state, "PACKAGE_MISSING");
+
+	const absoluteWindowsRoot = await fixture(t);
+	await write(absoluteWindowsRoot, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "cmd.exe"\nargs = ["/d", "/s", "/c", "node C:\\\\tools\\\\openapi-to-mcp --workspace-root ."]\n`);
+	const absoluteWindows = (await inspect(absoluteWindowsRoot)).value;
+	assert.equal(absoluteWindows.state, "BLOCKED");
+	assert.equal(absoluteWindows.codex.absolutePathDetected, true);
+
+	const noncanonicalRoot = await fixture(t);
+	await write(noncanonicalRoot, ".codex/config.toml", `["mcp_servers"."openapi_to"]\ncommand = "pnpm"\n`);
+	const noncanonical = (await inspect(noncanonicalRoot)).value.codex;
+	assert.equal(noncanonical.inferredMode, "unknown");
+	assert.equal(noncanonical.manualReviewRequired, true);
+});
+
+test("inspector does not follow a supported config symlink outside the project", async (t) => {
+	const root = await fixture(t);
+	const outside = await mkdtemp(join(tmpdir(), "openapi-to-setup-outside-"));
+	t.after(() => rm(outside, { recursive: true, force: true }));
+	await write(outside, "secret-config.ts", "export default 'do-not-read';\n");
+	await symlink(join(outside, "secret-config.ts"), join(root, "openapi.config.ts"));
+	const { value, output } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("GENERATION_CONFIG_OUTSIDE_ROOT"));
+	assert.doesNotMatch(output, /do-not-read/);
+});
+
+test("inspector output remains bounded for many matching dependency declarations", async (t) => {
+	const dependencies = { "openapi-to": "4.2.0" };
+	for (let index = 0; index < 500; index += 1) dependencies[`@openapi-to/example-${index}`] = "4.2.0";
+	const root = await fixture(t, { private: true, packageManager: "pnpm@10.14.0", devDependencies: dependencies });
+	const { value, output } = await inspect(root);
+	assert.equal(value.dependencies.total, 501);
+	assert.equal(value.dependencies.packages.length, 100);
+	assert.equal(value.dependencies.omitted, 401);
+	assert.ok(Buffer.byteLength(output) < 64 * 1024);
+});
+
+test("plan hash is canonical for object keys, deterministic, and array-order sensitive", async () => {
+	const firstPlan = setupPlan({
+		actions: [{ kind: "run-command", command: "pnpm", args: ["exec", "openapi", "init"], network: false, expectedWrites: ["openapi.config.ts", ".gitignore"] }],
+		verification: ["config", "ignore"],
+	});
+	const reordered = {
+		verification: ["config", "ignore"],
+		actions: [{ expectedWrites: ["openapi.config.ts", ".gitignore"], network: false, args: ["exec", "openapi", "init"], command: "pnpm", kind: "run-command" }],
+		packageManager: "pnpm",
+		restartRequired: true,
+		observedStateHash: "a".repeat(64),
+		mode: "read-only",
+		schemaVersion: 1,
+	};
+	const first = await hash(firstPlan);
+	const second = await hash(reordered);
+	const repeated = await hash(firstPlan);
+	assert.equal(first.setupPlanId, second.setupPlanId);
+	assert.equal(first.setupPlanId, repeated.setupPlanId);
+	assert.equal(JSON.parse(first.canonicalJson).schemaVersion, 1);
+	const reversed = await hash({ ...firstPlan, verification: ["ignore", "config"] });
+	assert.notEqual(first.setupPlanId, reversed.setupPlanId);
+});
+
+test("plan hash rejects sensitive fields, absolute paths, shell expressions, and escaping paths", async () => {
+	for (const key of ["token", "authorization", "cookie", "secret", "password", "headers", "env"]) {
+		await rejectHash(setupPlan({ [key]: "private" }), /forbidden sensitive field/);
+	}
+	await rejectHash(setupPlan({ actions: [{ kind: "create-file", path: "/tmp/config.toml" }] }), /must not be absolute/);
+	await rejectHash(setupPlan({ actions: [{ kind: "create-file", path: "../config.toml" }] }), /stay inside the project root/);
+	await rejectHash(setupPlan({ actions: [{ kind: "run-command", command: "pnpm && curl", args: [], network: false }] }), /program name/);
+	await rejectHash(setupPlan({ actions: [{ kind: "run-command", command: "pnpm", args: ["--dir", "C:\\temp"], network: false }] }), /absolute or escaping target path/);
+	await rejectHash(setupPlan({ actions: [{ kind: "run-command", command: "pnpm", args: ["--dir", "../outside"], network: false }] }), /absolute or escaping target path/);
+	await rejectHash(setupPlan({ actions: [{ kind: "create-file", path: "openapi.config.ts", content: "export default {};", sha256: "not-a-hash" }] }), /sha256 must be a lowercase SHA-256/);
+});
+
+test("plan hash rejects oversized and invalid schemas", async () => {
+	await rejectHash("x".repeat(256 * 1024 + 1), /exceeds the input size limit/);
+	await rejectHash({ ...setupPlan(), schemaVersion: 2 }, /schemaVersion must equal 1/);
+	await rejectHash({ ...setupPlan(), observedStateHash: "not-a-hash" }, /observedStateHash/);
+	await rejectHash({ ...setupPlan(), actions: "install" }, /actions must be a bounded array/);
+	await rejectHash({ ...setupPlan(), futureAuthority: true }, /unsupported field futureAuthority/);
+});
+
+test("plan hash accepts an explicit JSON file without modifying it", async (t) => {
+	const root = await mkdtemp(join(tmpdir(), "openapi-to-setup-plan-"));
+	t.after(() => rm(root, { recursive: true, force: true }));
+	const planPath = join(root, "plan.json");
+	const source = `${JSON.stringify(setupPlan())}\n`;
+	await writeFile(planPath, source);
+	const { stdout, stderr } = await execFileAsync(process.execPath, [hasher, "--file", planPath]);
+	assert.equal(stderr, "");
+	assert.match(JSON.parse(stdout).setupPlanId, /^[a-f0-9]{64}$/);
+	assert.equal(await readFile(planPath, "utf8"), source);
+});

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -42,6 +42,7 @@ const DOCUMENT_ENTRYPOINTS = [
 	"docs/cli.md",
 	"docs/codex-mcp.md",
 	"docs/skills.md",
+	"docs/setup-skill.md",
 	"docs/mcp-security.md",
 	"docs/troubleshooting.md",
 	"docs/ai-hosts/claude-code.md",
@@ -63,6 +64,7 @@ const SKILL_ROOT = ".agents/skills";
 export const REQUIRED_SKILLS = [
 	"implement-and-review",
 	"openapi-to-generate",
+	"openapi-to-setup",
 ];
 const PRIMARY_ORCHESTRATOR_MARKER = "## Primary orchestrator";
 const IMPLEMENT_AND_REVIEW_HEADINGS = [
@@ -81,6 +83,39 @@ const ARCHITECTURE_DOCUMENT = "docs/agents/agents-and-skills-architecture.md";
 const CONSUMER_SKILL_NAME = "openapi-to-generate";
 const CONSUMER_SKILL_DOCUMENT = "docs/skills.md";
 const CONSUMER_SKILL_EVALUATION = `${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/references/evaluation-matrix.yaml`;
+const SETUP_SKILL_NAME = "openapi-to-setup";
+const SETUP_SKILL_DOCUMENT = "docs/setup-skill.md";
+const SETUP_SKILL_EVALUATION = `${SKILL_ROOT}/${SETUP_SKILL_NAME}/references/evaluation-matrix.yaml`;
+const SETUP_SKILL_REQUIRED_FILES = [
+	"agents/openai.yaml",
+	"references/diagnosis.md",
+	"references/codex-setup.md",
+	"references/safe-writes.md",
+	"references/evaluation-matrix.yaml",
+	"scripts/inspect-project.mjs",
+	"scripts/hash-setup-plan.mjs",
+];
+const SETUP_EVALUATION_MINIMUMS = new Map([
+	["trigger", 8],
+	["reject", 8],
+	["degraded", 10],
+	["write-approval", 6],
+]);
+const REQUIRED_SETUP_EVALUATION_CASES = [
+	"degraded-package-missing",
+	"degraded-global-only",
+	"degraded-mcp-only",
+	"degraded-package-manager-conflict",
+	"degraded-multiple-configs",
+	"degraded-existing-codex-section",
+	"degraded-write-without-prompt",
+	"degraded-not-restarted",
+	"degraded-count-schema-mismatch",
+	"degraded-windows",
+	"approval-exact",
+	"approval-continue",
+	"approval-state-drift",
+];
 const CONSUMER_OPERATION_EXAMPLE_FILES = [
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/SKILL.md`,
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/references/mcp-workflow.md`,
@@ -112,6 +147,7 @@ const REQUIRED_CONSUMER_DEGRADED_CASES = new Map([
 export const EXPECTED_SKILL_ROLES = new Map([
 	["implement-and-review", "general-primary"],
 	[CONSUMER_SKILL_NAME, "specialized-primary"],
+	[SETUP_SKILL_NAME, "specialized-primary"],
 	["fix-github-actions", "specialized-primary"],
 	["release-monorepo", "specialized-primary"],
 	["add-cli-command", "domain-support"],
@@ -2583,6 +2619,136 @@ async function validateOpenapiToGenerateFiles(
 	}
 }
 
+function validateOpenapiToSetupSkill(contents, failures) {
+	let metadata;
+	try {
+		metadata = parseSkillFrontmatter(contents);
+	} catch {
+		return;
+	}
+	for (const marker of [
+		"Use when",
+		"consuming project",
+		"installed",
+		"initialized",
+		"Codex MCP",
+		"3/8/10 Tools",
+		"Do not use for API operation discovery or client generation",
+		"openapi-to-generate",
+		"does not upgrade existing versions",
+		"publish packages",
+		"openapi-to Monorepo",
+		"bypass Setup Plan or Apply approval",
+	]) {
+		if (!metadata.description.includes(marker)) {
+			failures.push(`${SETUP_SKILL_NAME} description is missing trigger boundary ${marker}`);
+		}
+	}
+	const normalized = contents.replace(/\s+/g, " ");
+	for (const marker of [
+		"Use `read-only` when the request is ambiguous",
+		"pnpm add -D --save-exact openapi-to@<exact-version>",
+		"Never choose `latest`",
+		"Do not use a global installation",
+		"Automatic package mutation is supported for pnpm only",
+		"pnpm exec openapi init",
+		"Do not invent `--yes`, `--force`",
+		"Never overwrite one config or choose among multiple configs",
+		"observedStateHash",
+		"setupPlanId",
+		"批准执行 Setup Plan <exact-setupPlanId>",
+		"re-inspect, create a new plan and ID",
+		"RESTART_REQUIRED",
+		"actual Tool list",
+		"current Tool inputSchema",
+		"approval_mode = \"prompt\"",
+		"manual review and do not overwrite or delete it",
+		"openapi-to-generate",
+	]) {
+		if (!normalized.includes(marker)) failures.push(`${SETUP_SKILL_NAME} is missing required workflow marker ${marker}`);
+	}
+	if (contents.includes(".OpenAPI/openapi.config.ts")) {
+		failures.push(`${SETUP_SKILL_NAME} must not use legacy config path .OpenAPI/openapi.config.ts`);
+	}
+	if (contents.split(/\r?\n/).length > 250) failures.push(`${SETUP_SKILL_NAME} SKILL.md must not exceed 250 lines`);
+}
+
+function validateOpenapiToSetupInterface(metadata, relativePath, failures) {
+	const expected = {
+		display_name: "Set up openapi-to",
+		short_description: "Diagnose and configure local openapi-to and Codex MCP",
+		default_prompt: "Use $openapi-to-setup to inspect this consuming project, prepare a bounded setup plan, and apply only the explicitly approved installation or configuration changes.",
+	};
+	for (const [field, expectedValue] of Object.entries(expected)) {
+		if (metadata[field] !== expectedValue) failures.push(`${relativePath} ${field} must equal ${JSON.stringify(expectedValue)}`);
+	}
+	if (metadata.dependencies !== undefined) failures.push(`${relativePath} must not require MCP availability as a Skill dependency`);
+}
+
+async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByName, failures) {
+	const skillContents = skillContentsByName.get(SETUP_SKILL_NAME);
+	if (skillContents) validateOpenapiToSetupSkill(skillContents, failures);
+	for (const relativeFile of SETUP_SKILL_REQUIRED_FILES) {
+		const relativePath = `${SKILL_ROOT}/${SETUP_SKILL_NAME}/${relativeFile}`;
+		if (!(await exists(join(root, relativePath)))) failures.push(`missing setup Skill file ${relativePath}`);
+		else if (!trackedFiles.has(relativePath)) failures.push(`setup Skill file is not tracked by Git: ${relativePath}`);
+	}
+
+	const documentPath = join(root, SETUP_SKILL_DOCUMENT);
+	if (!(await exists(documentPath))) failures.push(`missing setup Skill documentation ${SETUP_SKILL_DOCUMENT}`);
+	else if (!trackedFiles.has(SETUP_SKILL_DOCUMENT)) failures.push(`setup Skill documentation is not tracked by Git: ${SETUP_SKILL_DOCUMENT}`);
+	else {
+		const document = await readFile(documentPath, "utf8");
+		for (const marker of [
+			"openapi-to-setup",
+			"openapi-to-generate",
+			"read-only",
+			"Setup Plan",
+			"openapi init",
+			"does not upgrade",
+			"RESTART_REQUIRED",
+			"inputSchema",
+			"Codex-first",
+			"pnpm",
+			"npm, Yarn, and Bun",
+		]) {
+			if (!document.includes(marker)) failures.push(`${SETUP_SKILL_DOCUMENT} is missing setup workflow marker ${marker}`);
+		}
+	}
+
+	const evaluationPath = join(root, SETUP_SKILL_EVALUATION);
+	if (!(await exists(evaluationPath)) || !trackedFiles.has(SETUP_SKILL_EVALUATION)) return;
+	let evaluation;
+	try {
+		evaluation = loadYaml(await readFile(evaluationPath, "utf8"), { filename: SETUP_SKILL_EVALUATION });
+	} catch (error) {
+		failures.push(`${SETUP_SKILL_EVALUATION} contains invalid YAML: ${error?.reason ?? "parse failed"}`);
+		return;
+	}
+	if (!isMapping(evaluation) || evaluation.schema_version !== 1 || evaluation.kind !== "static_skill_evaluation_inputs" || !Array.isArray(evaluation.cases)) {
+		failures.push(`${SETUP_SKILL_EVALUATION} must contain schema_version 1, static kind, and a cases array`);
+		return;
+	}
+	const counts = new Map([...SETUP_EVALUATION_MINIMUMS.keys()].map((category) => [category, 0]));
+	const ids = new Set();
+	for (const [index, evaluationCase] of evaluation.cases.entries()) {
+		if (!isMapping(evaluationCase) || !["id", "category", "prompt", "expected"].every((field) => typeof evaluationCase[field] === "string" && evaluationCase[field].trim())) {
+			failures.push(`${SETUP_SKILL_EVALUATION} case ${index + 1} must define non-empty id, category, prompt, and expected strings`);
+			continue;
+		}
+		if (ids.has(evaluationCase.id)) failures.push(`${SETUP_SKILL_EVALUATION} contains duplicate id ${evaluationCase.id}`);
+		ids.add(evaluationCase.id);
+		if (!counts.has(evaluationCase.category)) failures.push(`${SETUP_SKILL_EVALUATION} has unsupported category ${evaluationCase.category}`);
+		else counts.set(evaluationCase.category, counts.get(evaluationCase.category) + 1);
+	}
+	for (const [category, minimum] of SETUP_EVALUATION_MINIMUMS) {
+		if (counts.get(category) < minimum) failures.push(`${SETUP_SKILL_EVALUATION} requires at least ${minimum} ${category} cases, found ${counts.get(category)}`);
+	}
+	for (const id of REQUIRED_SETUP_EVALUATION_CASES) {
+		if (!ids.has(id)) failures.push(`${SETUP_SKILL_EVALUATION} is missing required case ${id}`);
+	}
+}
+
 export async function auditAgentAndSkillContracts(
 	root,
 	{ rootManifest, workspaceManifests = new Map() } = {},
@@ -2749,6 +2915,9 @@ export async function auditAgentAndSkillContracts(
 						failures,
 					);
 				}
+				if (directoryName === SETUP_SKILL_NAME) {
+					validateOpenapiToSetupInterface(interfaceMetadata, relativeOpenAiYaml, failures);
+				}
 				if (!interfaceMetadata.display_name.trim())
 					failures.push(`${relativeOpenAiYaml} display_name must not be empty`);
 				if (
@@ -2853,6 +3022,7 @@ export async function auditAgentAndSkillContracts(
 		skillContentsByName,
 		failures,
 	);
+	await validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByName, failures);
 
 	const rootAgentPath = join(root, "AGENTS.md");
 	if (await exists(rootAgentPath)) {

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -77,6 +77,13 @@ function consumerSkillFile(relativePath) {
 	);
 }
 
+function setupSkillFile(relativePath) {
+	return readFile(
+		join(repositoryRoot, ".agents/skills/openapi-to-setup", relativePath),
+		"utf8",
+	);
+}
+
 function releaseSkillContents() {
 	return `---
 name: release-monorepo
@@ -215,6 +222,8 @@ async function createContractFixture(t) {
 				? await implementationSkillContents()
 				: skillName === "openapi-to-generate"
 					? await consumerSkillFile("SKILL.md")
+					: skillName === "openapi-to-setup"
+						? await setupSkillFile("SKILL.md")
 				: skillName === "release-monorepo"
 					? releaseSkillContents()
 					: skillContents(skillName),
@@ -224,6 +233,8 @@ async function createContractFixture(t) {
 			`.agents/skills/${skillName}/agents/openai.yaml`,
 			skillName === "openapi-to-generate"
 				? await consumerSkillFile("agents/openai.yaml")
+				: skillName === "openapi-to-setup"
+					? await setupSkillFile("agents/openai.yaml")
 				: skillInterface(skillName),
 		);
 	}
@@ -238,6 +249,20 @@ async function createContractFixture(t) {
 			await consumerSkillFile(relativePath),
 		);
 	}
+	for (const relativePath of [
+		"references/diagnosis.md",
+		"references/codex-setup.md",
+		"references/safe-writes.md",
+		"references/evaluation-matrix.yaml",
+		"scripts/inspect-project.mjs",
+		"scripts/hash-setup-plan.mjs",
+	]) {
+		await writeFixtureFile(
+			root,
+			`.agents/skills/openapi-to-setup/${relativePath}`,
+			await setupSkillFile(relativePath),
+		);
+	}
 	await writeFixtureFile(root, "AGENTS.md", rootAgentContents());
 	await writeFixtureFile(
 		root,
@@ -248,6 +273,11 @@ async function createContractFixture(t) {
 		root,
 		"docs/skills.md",
 		await readFile(join(repositoryRoot, "docs/skills.md"), "utf8"),
+	);
+	await writeFixtureFile(
+		root,
+		"docs/setup-skill.md",
+		await readFile(join(repositoryRoot, "docs/setup-skill.md"), "utf8"),
 	);
 	await writeFixtureFile(root, "scripts/known.mjs", "export {};\n");
 	await git(root, "add", "--", ".");
@@ -353,9 +383,11 @@ test("repository scripts, workspaces, docs, packages, and binary claims stay ali
 	assert.ok(result.skills.includes("fix-codegen-regression"));
 	assert.ok(result.skills.includes("implement-and-review"));
 	assert.ok(result.skills.includes("openapi-to-generate"));
+	assert.ok(result.skills.includes("openapi-to-setup"));
 	assert.deepEqual(REQUIRED_SKILLS, [
 		"implement-and-review",
 		"openapi-to-generate",
+		"openapi-to-setup",
 	]);
 });
 
@@ -1490,6 +1522,48 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 	);
 });
 
+test("consumer setup Skill preserves routing, safety, files, and evaluation contracts", async (t) => {
+	const cases = [
+		{
+			path: ".agents/skills/openapi-to-setup/SKILL.md",
+			mutate: (contents) => contents.replace("Use `read-only` when the request is ambiguous", "Use `write-enabled` when the request is ambiguous"),
+			failure: /missing required workflow marker Use `read-only` when the request is ambiguous/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/SKILL.md",
+			mutate: (contents) => contents.replace("Never choose `latest`", "Choose `latest`"),
+			failure: /missing required workflow marker Never choose `latest`/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/SKILL.md",
+			mutate: (contents) => contents.replace("re-inspect, create a new plan and ID", "reuse the old plan"),
+			failure: /missing required workflow marker re-inspect, create a new plan and ID/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/agents/openai.yaml",
+			mutate: (contents) => contents.replace("Diagnose and configure local openapi-to and Codex MCP", "Configure openapi-to"),
+			failure: /short_description must equal/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) => contents.replace("degraded-count-schema-mismatch", "degraded-count-only"),
+			failure: /missing required case degraded-count-schema-mismatch/,
+		},
+	];
+	for (const contractCase of cases) {
+		const root = await createContractFixture(t);
+		await mutateTrackedFixture(root, contractCase.path, contractCase.mutate);
+		assertFailure(await auditAgentAndSkillContracts(root), contractCase.failure);
+	}
+
+	const missingScriptRoot = await createContractFixture(t);
+	await git(missingScriptRoot, "rm", "--cached", "--", ".agents/skills/openapi-to-setup/scripts/inspect-project.mjs");
+	assertFailure(
+		await auditAgentAndSkillContracts(missingScriptRoot),
+		/setup Skill file is not tracked by Git: .*inspect-project\.mjs/,
+	);
+});
+
 test("workspace parser accepts only quoted package entries", () => {
 	assert.deepEqual(
 		parseWorkspacePatterns(`packages:
@@ -2250,6 +2324,13 @@ test("Skill routing audit enforces every explicit role", async (t) => {
 				/role for openapi-to-generate must be specialized-primary, found domain-support/,
 		},
 		{
+			name: "openapi-to-setup",
+			from: "Specialized primary",
+			to: "Support",
+			failure:
+				/role for openapi-to-setup must be specialized-primary, found domain-support/,
+		},
+		{
 			name: "fix-github-actions",
 			from: "Specialized primary",
 			to: "Support",
@@ -2358,13 +2439,13 @@ test("architecture role inventory stays aligned with tracked Skills and routing 
 		"docs/agents/agents-and-skills-architecture.md",
 		(contents) =>
 			contents.replace(
+				"Tracked Skill count: `12`.",
 				"Tracked Skill count: `11`.",
-				"Tracked Skill count: `10`.",
 			),
 	);
 	assertFailure(
 		await auditAgentAndSkillContracts(countRoot),
-		/tracked Skill count must equal 11/,
+		/tracked Skill count must equal 12/,
 	);
 
 	const roleRoot = await createContractFixture(t);


### PR DESCRIPTION
## Summary

- add the specialized-primary `openapi-to-setup` consuming-project Skill
- add a bounded read-only project inspector and deterministic Setup Plan hasher
- document read-only defaults, approval-bound writes, Codex-first setup, restart verification, and handoff to `openapi-to-generate`
- extend repository contracts, static evaluation inputs, focused Node tests, and documentation

## Safety boundaries

- no implicit upgrades or global-install fallback
- pnpm is the only automatic package-write path in this phase
- existing generation configs and Codex sections are not overwritten
- every mutation requires an exact state-bound Setup Plan approval
- Codex writes stop at `RESTART_REQUIRED`; 3/8/10 Tool counts remain directional until actual Tool Schemas are verified

## Validation

- `node --test scripts/openapi-to-setup.node-test.mjs` — PASS (12/12)
- `pnpm verify:repository-contract` — PASS
- `node --test scripts/repository-contract.node-test.mjs` — PASS (75/75)
- `pnpm test:release-scripts` — PASS (151/151)
- `pnpm lint:ci` — PASS
- `pnpm lint:changed --base c9c3a48ee2b33358a1cf7e0bc986337a8e8a9813` — PASS
- `pnpm verify:precommit` — PASS (12-package build; 657 tests passed, 2 skipped)
- `git diff --check c9c3a48ee2b33358a1cf7e0bc986337a8e8a9813..HEAD` — PASS

## Review and packaging

- two complete task-base review rounds completed; P0 = 0, P1 = 0, P2 = 0
- official Skill installer smoke from this branch — PASS; installed bytes match the branch and explicit `$openapi-to-setup` selection metadata is present
- Changeset: not required because this changes repository Skills, tests, contracts, and docs only; no public npm package or runtime behavior changed
- Recovery/performance/stress: SKIPPED because no runtime, Core, CLI, MCP, or plugin implementation changed
