### PR TITLE
Harden openapi-to setup state binding

### DIFF
--- a/.agents/skills/openapi-to-setup/SKILL.md
+++ b/.agents/skills/openapi-to-setup/SKILL.md
@@ -51,10 +51,13 @@ Run the standard-library inspector from this Skill directory:
 node scripts/inspect-project.mjs --root <consuming-project-root>
 ```
 
-The script reads bounded metadata only. It does not execute
-`openapi.config.*`, run a shell command, inspect global installations, read
-`.openapi-to/` contents, access the network, read environment variables, or
-return project configuration bodies or credentials.
+The script reads bounded metadata only. Its `observedStateHash` binds raw-byte
+SHA-256 values for `package.json`, every detected lockfile, generation config,
+`.gitignore`, and `.codex/config.toml`; lockfiles are streamed with a 32 MiB
+limit. It does not return those file bodies, execute `openapi.config.*`, run a
+shell command, inspect global installations, read `.openapi-to/` contents,
+access the network, read environment variables, or return project
+configuration bodies or credentials.
 
 During diagnosis, do not install packages, run `openapi init`, change
 `.gitignore`, edit `.codex/config.toml`, or enable writes. If the user asked
@@ -80,6 +83,11 @@ Package declaration, a config filename, local command resolution, Host file
 configuration, Host restart, Server connection, and verified Tool capability
 are different evidence. Writing `.codex/config.toml` always yields
 `RESTART_REQUIRED`; it never proves the running Host reloaded the Server.
+`PACKAGE_JSON_MISSING` is a blocking reason because the current directory is
+not a confirmed Node consuming project; never create a new Node project or plan
+an install there. `PACKAGE_MISSING` applies only when a valid `package.json`
+exists, the project boundary is trusted, and the aggregate `openapi-to`
+declaration alone is missing.
 
 ## 4. Plan the minimum setup
 
@@ -140,6 +148,15 @@ approval. Never run diagnosis, install, init, and Host edits as an automatic
 chain. If `package.json`, a lockfile, generation config, `.gitignore`, Codex
 config, or overlapping Git state changes, re-inspect, create a new plan and ID,
 show it, and obtain new exact approval.
+
+The state binding covers manifest bytes, every lockfile's name, size, and
+bytes, generation config bytes, ignore bytes, Codex config bytes, their
+existence states, package/dependency diagnostics, conservative Codex
+diagnostics, and blocking reasons. It does not cover the whole worktree,
+`node_modules`, `.git`, `.openapi-to/` contents, environment variables, global
+installs, or network state. Multiple actual lockfiles—including two names for
+one manager—are a conflict. Oversized, unreadable, or out-of-root lockfiles fail
+closed. Git status remains a separate pre-apply check.
 
 ## 6. Apply only the approved actions
 

--- a/.agents/skills/openapi-to-setup/references/diagnosis.md
+++ b/.agents/skills/openapi-to-setup/references/diagnosis.md
@@ -9,8 +9,8 @@ Schema is compatible.
 | State | Evidence | Next decision |
 | --- | --- | --- |
 | `UNINSPECTED` | No current inspector result | Read rules, Git state, and run the inspector. |
-| `BLOCKED` | Conflicting package-manager evidence, multiple configs, unsafe symlink, oversized/invalid metadata, version conflict, or duplicate Codex section | Stop writes and report the exact bounded reason. |
-| `PACKAGE_MISSING` | No aggregate `openapi-to` declaration | Plan an exact-version aggregate install or request a version decision. |
+| `BLOCKED` | Missing manifest, conflicting package-manager evidence, multiple configs, unsafe symlink, oversized/invalid metadata, version conflict, or duplicate Codex section | Stop writes and report the exact bounded reason. |
+| `PACKAGE_MISSING` | A valid manifest and trusted project boundary have no aggregate `openapi-to` declaration or other blocker | Plan an exact-version aggregate install or request a version decision. |
 | `PACKAGE_READY` | Aggregate package is declared locally | Continue to generation config; do not infer that binaries resolve. |
 | `CONFIG_MISSING` | No supported root config | Plan the existing `pnpm exec openapi init`. |
 | `CONFIG_READY` | Exactly one supported config exists | Treat it as trusted executable project code only when validation is approved. |
@@ -25,20 +25,29 @@ Schema is compatible.
 
 - `schemaVersion` identifies the JSON contract.
 - `observedStateHash` is SHA-256 over the canonical observation without the
-  hash. Bind a Setup Plan to this exact value.
+  hash. It binds the manifest raw-byte hash; every detected lockfile name, size,
+  and raw-byte hash; generation config, `.gitignore`, and Codex config raw-byte
+  hashes; relevant existence states; package-manager and dependency
+  diagnostics; conservative Codex diagnostics; and blocking reasons. Bind a
+  Setup Plan to this exact value. It does not bind the whole worktree.
 - `blockingReasons` is sorted and closed: do not guess through a reason.
 - `workspace` reports only bounded booleans, a relative root marker, and the
-  running Node major/support decision. It never prints the absolute Workspace.
+  running Node major/support decision. `workspace.packageJson.sha256` hashes
+  original bytes even when JSON is invalid, is `null` when missing, and never
+  exposes the manifest. It never prints the absolute Workspace.
 - `packageManager` prefers `package.json#packageManager`, then a unique lockfile
-  manager. A mismatch or multiple managers is `conflict`; only pnpm is an
-  automatic write path in this phase.
+  only when exactly one actual lockfile exists. Any multiple actual lockfiles,
+  including multiple names for one manager, are `conflict`; only pnpm is an
+  automatic write path in this phase. Each lockfile record contains its
+  relative name, manager, size, and streamed raw-byte SHA-256.
 - `dependencies` lists only manifest declarations for `openapi-to` and
   `@openapi-to/*`, their dependency section and range. It does not inspect a
   global installation or claim that a declared package resolves.
 - `generationConfig` checks only `openapi.config.ts`, `.js`, `.cjs`, and `.mjs`
   at the root. It hashes bytes without importing or executing the file.
 - `runtimeState` checks `.openapi-to/` presence and a conservative explicit
-  root ignore rule. It never reads state contents.
+  root ignore rule. `gitignoreSha256` binds all original `.gitignore` bytes
+  while no body is returned. It never reads state contents.
 - `codex` hashes `.codex/config.toml` and uses conservative section/text
   inspection. It never returns TOML content, credentials, command bodies, or
   environment data. `parser: conservative-text-inspection` is deliberately not
@@ -62,6 +71,14 @@ not supply safe version evidence.
 ## Failure-closed rules
 
 - More than one supported generation config is `BLOCKED`; do not select one.
+- Missing `package.json` is `PACKAGE_JSON_MISSING` and `BLOCKED`; do not create
+  a Node project or plan an install. `PACKAGE_MISSING` requires a valid
+  manifest, a trusted boundary, and no other blocker.
+- Multiple actual lockfiles are `PACKAGE_MANAGER_CONFLICT`, even when their
+  filenames map to the same manager.
+- Lockfiles are hashed through the verified open file handle and limited to
+  32 MiB. Oversized files produce `LOCKFILE_TOO_LARGE`; unreadable, replaced,
+  symlinked, or out-of-root files fail closed without returning contents.
 - An invalid/oversized package, config, ignore, or Codex metadata file is
   `BLOCKED`; do not truncate and proceed.
 - A symlink that resolves outside the real project root is `BLOCKED` and is not

--- a/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
@@ -71,6 +71,30 @@ cases:
     category: degraded
     prompt: "项目没有 openapi-to，版本也没有指定"
     expected: request_exact_version_before_install
+  - id: degraded-package-json-missing
+    category: degraded
+    prompt: "当前目录没有 package.json"
+    expected: block_without_install_plan
+  - id: degraded-package-json-drift-after-approval
+    category: degraded
+    prompt: "批准后 package.json 的其他字段发生变化"
+    expected: invalidate_setup_plan
+  - id: degraded-lockfile-drift-after-approval
+    category: degraded
+    prompt: "批准后锁文件内容发生变化"
+    expected: invalidate_setup_plan
+  - id: degraded-gitignore-drift-after-approval
+    category: degraded
+    prompt: "批准后 .gitignore 的无关内容发生变化"
+    expected: invalidate_setup_plan
+  - id: degraded-multiple-same-manager-lockfiles
+    category: degraded
+    prompt: "项目同时存在 package-lock.json 和 npm-shrinkwrap.json"
+    expected: block_package_manager_conflict
+  - id: degraded-lockfile-too-large
+    category: degraded
+    prompt: "锁文件超过 inspector 的 32 MiB 上限"
+    expected: fail_closed_without_reading_contents
   - id: degraded-global-only
     category: degraded
     prompt: "全局 openapi 命令存在，但项目 manifest 没有依赖"

--- a/.agents/skills/openapi-to-setup/references/safe-writes.md
+++ b/.agents/skills/openapi-to-setup/references/safe-writes.md
@@ -62,9 +62,19 @@ and `setupPlanId`. Accept only explicit approval naming that exact ID, such as:
 
 “Continue”, “install”, “configure it”, “looks good”, and “use defaults” are not
 approval. Before applying, re-run the inspector and require the same
-`observedStateHash`. Re-read Git status. Drift in the manifest, lockfile,
-generation config, ignore file, Codex file, or overlapping worktree invalidates
-the plan. Re-plan, re-hash, re-display, and obtain new exact approval.
+`observedStateHash`. It binds raw-byte SHA-256 values for the manifest, every
+lockfile, generation config, ignore file, and Codex file, plus the relevant
+diagnostics and existence states. Re-read Git status separately because the
+hash does not cover the whole worktree. Drift in any bound file or overlapping
+worktree invalidates the plan. Re-plan, re-hash to a new `setupPlanId`,
+re-display, and obtain new exact approval.
+
+Missing `package.json` is `PACKAGE_JSON_MISSING` and blocks planning; never
+create a Node project implicitly. `PACKAGE_MISSING` is reserved for a trusted
+project with a valid manifest and no aggregate package declaration. Multiple
+actual lockfiles conflict even when they map to one manager. Lockfiles are
+streamed with a 32 MiB limit, and oversized, unreadable, symlinked, replaced, or
+out-of-root files fail closed without returning their contents.
 
 ## Package install
 

--- a/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
@@ -8,6 +8,7 @@ import process from "node:process";
 
 const SCHEMA_VERSION = 1;
 const MAX_FILE_BYTES = 128 * 1024;
+const MAX_LOCKFILE_BYTES = 32 * 1024 * 1024;
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const MAX_DEPENDENCY_RESULTS = 100;
 const SUPPORTED_CONFIG_FILES = [
@@ -56,11 +57,40 @@ function isInside(root, candidate) {
 	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
+function openedEntryMatches(info, opened) {
+	return info.dev === opened.dev && info.ino === opened.ino;
+}
+
+function unchangedDuringRead(before, after) {
+	return (
+		before.dev === after.dev &&
+		before.ino === after.ino &&
+		before.size === after.size &&
+		before.mtimeMs === after.mtimeMs &&
+		before.ctimeMs === after.ctimeMs
+	);
+}
+
+function noFollowReadFlags() {
+	return Number.isInteger(constants.O_NOFOLLOW)
+		? constants.O_RDONLY | constants.O_NOFOLLOW
+		: undefined;
+}
+
 async function entryInfo(root, relativePath) {
 	const candidate = path.resolve(root, relativePath);
 	if (!isInside(root, candidate)) return { exists: false, unsafe: true };
+	let entry;
 	try {
-		const entry = await lstat(candidate);
+		entry = await lstat(candidate);
+	} catch (error) {
+		if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
+			return { exists: false, unsafe: false };
+		}
+		if (error?.code === "ELOOP") return { exists: true, unsafe: true, symlink: true };
+		throw error;
+	}
+	try {
 		const resolved = await realpath(candidate);
 		if (!isInside(root, resolved)) {
 			return { exists: true, unsafe: true, symlink: entry.isSymbolicLink() };
@@ -72,32 +102,88 @@ async function entryInfo(root, relativePath) {
 			isFile: entry.isFile(),
 			isDirectory: entry.isDirectory(),
 			size: entry.size,
+			dev: entry.dev,
+			ino: entry.ino,
 			path: candidate,
 		};
 	} catch (error) {
-		if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
-			return { exists: false, unsafe: false };
+		if (
+			error?.code === "ENOENT" ||
+			error?.code === "ENOTDIR" ||
+			error?.code === "ELOOP"
+		) {
+			return { exists: true, unsafe: true, symlink: entry.isSymbolicLink() };
 		}
-		if (error?.code === "ELOOP") return { exists: true, unsafe: true, symlink: true };
 		throw error;
+	}
+}
+
+async function openVerifiedFile(info) {
+	const flags = noFollowReadFlags();
+	if (flags === undefined) return { readError: true };
+	let handle;
+	try {
+		handle = await open(info.path, flags);
+		const opened = await handle.stat();
+		if (!opened.isFile() || !openedEntryMatches(info, opened)) {
+			await handle.close();
+			return { unsafe: true };
+		}
+		return { handle, opened };
+	} catch (error) {
+		await handle?.close();
+		if (error?.code === "ELOOP") return { unsafe: true };
+		return { readError: true };
 	}
 }
 
 async function readBoundedText(root, relativePath) {
 	const info = await entryInfo(root, relativePath);
-	if (!info.exists || info.unsafe || !info.isFile) return { info };
-	let handle;
+	if (!info.exists || info.unsafe) return { info };
+	if (!info.isFile) return { info, readError: true };
+	const openedFile = await openVerifiedFile(info);
+	if (!openedFile.handle) return { info: { ...info, unsafe: openedFile.unsafe === true }, readError: openedFile.readError === true };
+	const { handle, opened } = openedFile;
 	try {
-		handle = await open(info.path, constants.O_RDONLY | constants.O_NOFOLLOW);
-		const opened = await handle.stat();
-		if (!opened.isFile()) return { info: { ...info, unsafe: true } };
 		if (opened.size > MAX_FILE_BYTES) return { info, tooLarge: true };
-		return { info, text: await handle.readFile("utf8") };
-	} catch (error) {
-		if (error?.code === "ELOOP") return { info: { ...info, unsafe: true } };
-		throw error;
+		const bytes = await handle.readFile();
+		const after = await handle.stat();
+		if (bytes.byteLength !== opened.size || !unchangedDuringRead(opened, after)) {
+			return { info, readError: true };
+		}
+		return { info, text: bytes.toString("utf8"), sha256: sha256(bytes) };
+	} catch {
+		return { info, readError: true };
 	} finally {
-		await handle?.close();
+		await handle.close();
+	}
+}
+
+async function hashLockFile(root, relativePath) {
+	const info = await entryInfo(root, relativePath);
+	if (!info.exists || info.unsafe) return { info };
+	if (!info.isFile) return { info, readError: true };
+	const openedFile = await openVerifiedFile(info);
+	if (!openedFile.handle) return { info: { ...info, unsafe: openedFile.unsafe === true }, readError: openedFile.readError === true };
+	const { handle, opened } = openedFile;
+	try {
+		if (opened.size > MAX_LOCKFILE_BYTES) return { info, size: opened.size, tooLarge: true };
+		const hash = createHash("sha256");
+		let size = 0;
+		for await (const chunk of handle.createReadStream({ autoClose: false, start: 0 })) {
+			size += chunk.byteLength;
+			if (size > MAX_LOCKFILE_BYTES) return { info, size, tooLarge: true };
+			hash.update(chunk);
+		}
+		const after = await handle.stat();
+		if (size !== opened.size || !unchangedDuringRead(opened, after)) {
+			return { info, size, readError: true };
+		}
+		return { info, size, sha256: hash.digest("hex") };
+	} catch {
+		return { info, readError: true };
+	} finally {
+		await handle.close();
 	}
 }
 
@@ -214,8 +300,10 @@ async function inspect(rootArgument) {
 	const packageRead = await readBoundedText(root, "package.json");
 	let manifest;
 	let packageJsonValid = false;
-	if (packageRead.info.unsafe) blockingReasons.push("PACKAGE_JSON_OUTSIDE_ROOT");
+	if (!packageRead.info.exists) blockingReasons.push("PACKAGE_JSON_MISSING");
+	else if (packageRead.info.unsafe) blockingReasons.push("PACKAGE_JSON_OUTSIDE_ROOT");
 	else if (packageRead.tooLarge) blockingReasons.push("PACKAGE_JSON_TOO_LARGE");
+	else if (packageRead.readError) blockingReasons.push("PACKAGE_JSON_READ_FAILED");
 	else if (packageRead.text !== undefined) {
 		try {
 			manifest = JSON.parse(packageRead.text);
@@ -230,11 +318,18 @@ async function inspect(rootArgument) {
 	const declaredManager = packageManagerName(manifest?.packageManager);
 	const lockFiles = [];
 	for (const [file, manager] of LOCK_FILES) {
-		const info = await entryInfo(root, file);
-		if (info.unsafe) blockingReasons.push("LOCKFILE_OUTSIDE_ROOT");
-		if (info.exists && !info.unsafe) lockFiles.push({ file, manager });
+		const result = await hashLockFile(root, file);
+		if (!result.info.exists) continue;
+		lockFiles.push({
+			file,
+			manager,
+			sha256: result.sha256 ?? null,
+			size: result.size ?? null,
+		});
+		if (result.info.unsafe) blockingReasons.push("LOCKFILE_OUTSIDE_ROOT");
+		else if (result.tooLarge) blockingReasons.push("LOCKFILE_TOO_LARGE");
+		else if (result.readError) blockingReasons.push("LOCKFILE_READ_FAILED");
 	}
-	const lockManagers = [...new Set(lockFiles.map(({ manager }) => manager))].sort();
 	let detectedManager = "unknown";
 	let managerEvidence = "none";
 	if (hasDeclaredManager && !declaredManager) {
@@ -244,11 +339,16 @@ async function inspect(rootArgument) {
 	} else if (declaredManager) {
 		detectedManager = declaredManager;
 		managerEvidence = "packageManager";
-	} else if (!hasDeclaredManager && lockManagers.length === 1) {
-		detectedManager = lockManagers[0];
+	} else if (!hasDeclaredManager && lockFiles.length === 1) {
+		detectedManager = lockFiles[0].manager;
 		managerEvidence = "unique-lockfile-manager";
 	}
-	if (lockManagers.length > 1 || (declaredManager && lockManagers.some((value) => value !== declaredManager))) {
+	const lockfileConflict =
+		(!declaredManager && lockFiles.length > 1) ||
+		(declaredManager &&
+			(lockFiles.some(({ manager }) => manager !== declaredManager) ||
+				lockFiles.filter(({ manager }) => manager === declaredManager).length > 1));
+	if (lockfileConflict) {
 		detectedManager = "conflict";
 		managerEvidence = "conflicting-evidence";
 		blockingReasons.push("PACKAGE_MANAGER_CONFLICT");
@@ -267,7 +367,10 @@ async function inspect(rootArgument) {
 		if (read.tooLarge) {
 			blockingReasons.push("GENERATION_CONFIG_TOO_LARGE");
 			configFiles.push({ path: file, sha256: null });
-		} else if (read.text !== undefined) configFiles.push({ path: file, sha256: sha256(read.text) });
+		} else if (read.readError) {
+			blockingReasons.push("GENERATION_CONFIG_READ_FAILED");
+			configFiles.push({ path: file, sha256: null });
+		} else if (read.text !== undefined) configFiles.push({ path: file, sha256: read.sha256 });
 	}
 	if (configFiles.length > 1) blockingReasons.push("MULTIPLE_GENERATION_CONFIGS");
 
@@ -276,10 +379,12 @@ async function inspect(rootArgument) {
 	const gitignoreRead = await readBoundedText(root, ".gitignore");
 	if (gitignoreRead.info.unsafe) blockingReasons.push("GITIGNORE_OUTSIDE_ROOT");
 	if (gitignoreRead.tooLarge) blockingReasons.push("GITIGNORE_TOO_LARGE");
+	if (gitignoreRead.readError) blockingReasons.push("GITIGNORE_READ_FAILED");
 	const ignore = gitignoreStatus(gitignoreRead.text);
 	const codexRead = await readBoundedText(root, ".codex/config.toml");
 	if (codexRead.info.unsafe) blockingReasons.push("CODEX_CONFIG_OUTSIDE_ROOT");
 	if (codexRead.tooLarge) blockingReasons.push("CODEX_CONFIG_TOO_LARGE");
+	if (codexRead.readError) blockingReasons.push("CODEX_CONFIG_READ_FAILED");
 	const codexInspection = codexRead.text === undefined ? null : inspectCodexToml(codexRead.text);
 	if (codexInspection?.serverSectionCount > 1) blockingReasons.push("DUPLICATE_CODEX_SERVER_SECTION");
 	if (codexInspection?.configurationBlocked) blockingReasons.push("CODEX_CONFIG_MANUAL_REVIEW_REQUIRED");
@@ -299,7 +404,11 @@ async function inspect(rootArgument) {
 		blockingReasons: [...new Set(blockingReasons)].sort(),
 		workspace: {
 			root: ".",
-			packageJson: { exists: packageRead.info.exists === true, valid: packageJsonValid },
+			packageJson: {
+				exists: packageRead.info.exists === true,
+				valid: packageJsonValid,
+				sha256: packageRead.sha256 ?? null,
+			},
 			node: { major: nodeMajor, supported: nodeMajor >= 20 },
 			gitRepository: gitEntry.exists === true && !gitEntry.unsafe,
 		},
@@ -308,7 +417,10 @@ async function inspect(rootArgument) {
 			evidence: managerEvidence,
 			declared: declaredManager ?? null,
 			lockFiles,
-			automaticInstallSupported: detectedManager === "pnpm",
+			automaticInstallSupported:
+				detectedManager === "pnpm" &&
+				packageJsonValid &&
+				!blockingReasons.some((reason) => reason.startsWith("LOCKFILE_")),
 		},
 		dependencies,
 		generationConfig: {
@@ -319,12 +431,13 @@ async function inspect(rootArgument) {
 		runtimeState: {
 			directoryPresent: stateDirectory.exists === true && !stateDirectory.unsafe,
 			gitignorePresent: gitignoreRead.info.exists === true && !gitignoreRead.info.unsafe,
+			gitignoreSha256: gitignoreRead.sha256 ?? null,
 			ignored: ignore.ignored,
 			ignoreEvidence: ignore.evidence,
 		},
 		codex: {
 			configPresent: codexRead.info.exists === true && !codexRead.info.unsafe,
-			sha256: codexRead.text === undefined ? null : sha256(codexRead.text),
+			sha256: codexRead.sha256 ?? null,
 			...(codexInspection ?? {
 				serverSectionCount: 0,
 				applyPromptSectionCount: 0,

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -17,13 +17,25 @@ diagnosis, and 3/8/10 Tool-mode validation. A vague setup request defaults to
 The Skill's standard-library inspector reads bounded project metadata without
 executing `openapi.config.*`, walking generated/state directories, inspecting
 global packages, accessing the network, or returning configuration bodies and
-credentials. The workflow keeps local package declaration, one supported
-config, local command resolution, Host configuration, Host restart, Server
-connection, and verified Tool capability as distinct evidence.
+credentials. Its state hash binds raw-byte SHA-256 values for `package.json`,
+every detected lockfile, generation config, `.gitignore`, and Codex config,
+along with relevant existence states and diagnostics; it does not bind the
+whole worktree. Lockfiles are streamed and limited to 32 MiB. The workflow
+keeps local package declaration, one supported config, local command
+resolution, Host configuration, Host restart, Server connection, and verified
+Tool capability as distinct evidence.
 
 Supported root configs are `openapi.config.ts`, `.js`, `.cjs`, and `.mjs`.
 Multiple candidates block setup. `.openapi-to/` is runtime state; the retired
 `.OpenAPI` config location is not used.
+
+A missing manifest produces `PACKAGE_JSON_MISSING` and `BLOCKED`; setup never
+creates a Node project or plans an install in an unconfirmed directory.
+`PACKAGE_MISSING` means a valid `package.json` in a trusted project lacks only
+the aggregate package. Multiple actual lockfiles—including two filenames for
+the same manager—are a package-manager conflict. Oversized, unreadable,
+symlinked, replaced, or out-of-root lockfiles fail closed without returning
+their contents.
 
 ## Approval-bound writes
 
@@ -31,9 +43,10 @@ Every package install, initializer run, ignore change, and Codex config change
 requires a complete JSON Setup Plan bound to the current inspector state hash.
 The plan shows exact argv, network use, expected writes, direct file diffs,
 verification, and restart impact. Its canonical SHA-256 `setupPlanId` must be
-named in explicit user approval. If the manifest, lockfile, config, ignore file,
-Codex file, or overlapping Git state changes, the Skill discards the approval
-and creates a new plan.
+named in explicit user approval. If the manifest, any lockfile, config, ignore
+file, or Codex file changes, the Skill discards the approval, creates a new
+Setup Plan and `setupPlanId`, and requires new exact approval. Git worktree
+status is re-read separately immediately before execution.
 
 The Skill never uses a global install and does not upgrade an existing
 openapi-to version. Installation requires an exact version: explicit user

--- a/scripts/openapi-to-setup.node-test.mjs
+++ b/scripts/openapi-to-setup.node-test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -80,6 +80,9 @@ test("inspector reports a clean pnpm project with all setup capabilities missing
 	assert.equal(value.state, "PACKAGE_MISSING");
 	assert.equal(value.packageManager.value, "pnpm");
 	assert.equal(value.packageManager.evidence, "packageManager");
+	assert.match(value.workspace.packageJson.sha256, /^[a-f0-9]{64}$/);
+	assert.match(value.packageManager.lockFiles[0].sha256, /^[a-f0-9]{64}$/);
+	assert.equal(value.packageManager.lockFiles[0].size, 23);
 	assert.equal(value.dependencies.aggregate, null);
 	assert.equal(value.generationConfig.status, "missing");
 	assert.equal(value.runtimeState.ignored, false);
@@ -87,6 +90,45 @@ test("inspector reports a clean pnpm project with all setup capabilities missing
 	assert.match(value.observedStateHash, /^[a-f0-9]{64}$/);
 	assert.ok(Buffer.byteLength(output) < 64 * 1024);
 	assert.doesNotMatch(output, new RegExp(root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("inspector blocks a directory without package.json", async (t) => {
+	const root = await mkdtemp(join(tmpdir(), "openapi-to-setup-empty-"));
+	t.after(() => rm(root, { recursive: true, force: true }));
+	const { value } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("PACKAGE_JSON_MISSING"));
+	assert.deepEqual(value.workspace.packageJson, {
+		exists: false,
+		valid: false,
+		sha256: null,
+	});
+});
+
+test("inspector binds manifest raw bytes even when setup diagnostics do not change", async (t) => {
+	const root = await fixture(t);
+	const before = (await inspect(root)).value;
+	await write(root, "package.json", `${JSON.stringify({
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		scripts: { preinstall: "node changed.js" },
+	}, null, 2)}\n`);
+	const after = (await inspect(root)).value;
+	assert.deepEqual(after.packageManager, before.packageManager);
+	assert.deepEqual(after.dependencies, before.dependencies);
+	assert.notEqual(after.workspace.packageJson.sha256, before.workspace.packageJson.sha256);
+	assert.notEqual(after.observedStateHash, before.observedStateHash);
+});
+
+test("inspector hashes invalid package.json raw bytes while blocking it", async (t) => {
+	const root = await fixture(t);
+	await write(root, "package.json", '{"private":true\n');
+	const { value, output } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.equal(value.workspace.packageJson.valid, false);
+	assert.match(value.workspace.packageJson.sha256, /^[a-f0-9]{64}$/);
+	assert.ok(value.blockingReasons.includes("PACKAGE_JSON_INVALID"));
+	assert.doesNotMatch(output, /\{"private":true/);
 });
 
 test("inspector distinguishes aggregate and MCP-only dependency boundaries", async (t) => {
@@ -139,6 +181,80 @@ test("inspector blocks package-manager and openapi-to version conflicts", async 
 	assert.ok(unknown.blockingReasons.includes("PACKAGE_MANAGER_UNKNOWN"));
 });
 
+test("inspector blocks multiple same-manager lockfiles instead of deduplicating them", async (t) => {
+	for (const [manager, first, second] of [
+		["npm", "package-lock.json", "npm-shrinkwrap.json"],
+		["bun", "bun.lock", "bun.lockb"],
+	]) {
+		for (const manifest of [
+			{ private: true },
+			{ private: true, packageManager: `${manager}@1.0.0` },
+		]) {
+			const root = await fixture(t, manifest);
+			await write(root, first, "first lock\n");
+			await write(root, second, "second lock\n");
+			const { value } = await inspect(root);
+			assert.equal(value.state, "BLOCKED");
+			assert.equal(value.packageManager.value, "conflict");
+			assert.equal(value.packageManager.lockFiles.length, 2);
+			assert.ok(
+				value.packageManager.lockFiles.every(({ sha256 }) =>
+					/^[a-f0-9]{64}$/.test(sha256),
+				),
+			);
+			assert.ok(value.blockingReasons.includes("PACKAGE_MANAGER_CONFLICT"));
+		}
+	}
+});
+
+test("inspector binds lockfile raw bytes without changing manager evidence", async (t) => {
+	const root = await fixture(t);
+	await write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+	const before = (await inspect(root)).value;
+	await write(root, "pnpm-lock.yaml", "lockfileVersion: '9.1'\n");
+	const after = (await inspect(root)).value;
+	assert.equal(after.packageManager.value, before.packageManager.value);
+	assert.equal(after.packageManager.evidence, before.packageManager.evidence);
+	assert.equal(after.packageManager.lockFiles[0].file, before.packageManager.lockFiles[0].file);
+	assert.equal(after.packageManager.lockFiles[0].manager, before.packageManager.lockFiles[0].manager);
+	assert.notEqual(after.packageManager.lockFiles[0].sha256, before.packageManager.lockFiles[0].sha256);
+	assert.notEqual(after.observedStateHash, before.observedStateHash);
+});
+
+test("inspector blocks oversized lockfiles without loading their contents", async (t) => {
+	const root = await fixture(t);
+	const lockfile = join(root, "pnpm-lock.yaml");
+	await write(root, "pnpm-lock.yaml", "");
+	await truncate(lockfile, 32 * 1024 * 1024 + 1);
+	const { value } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("LOCKFILE_TOO_LARGE"));
+	assert.equal(value.packageManager.lockFiles[0].size, 32 * 1024 * 1024 + 1);
+	assert.equal(value.packageManager.lockFiles[0].sha256, null);
+});
+
+test("inspector does not follow a lockfile symlink outside the project", async (t) => {
+	const root = await fixture(t);
+	const outside = await mkdtemp(join(tmpdir(), "openapi-to-setup-lock-outside-"));
+	t.after(() => rm(outside, { recursive: true, force: true }));
+	await write(outside, "pnpm-lock.yaml", "external-lock-secret\n");
+	await symlink(join(outside, "pnpm-lock.yaml"), join(root, "pnpm-lock.yaml"));
+	const { value, output } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("LOCKFILE_OUTSIDE_ROOT"));
+	assert.equal(value.packageManager.lockFiles[0].sha256, null);
+	assert.doesNotMatch(output, /external-lock-secret/);
+});
+
+test("inspector fails closed on a dangling lockfile symlink", async (t) => {
+	const root = await fixture(t);
+	await symlink("missing-lock-target", join(root, "pnpm-lock.yaml"));
+	const { value } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("LOCKFILE_OUTSIDE_ROOT"));
+	assert.equal(value.packageManager.lockFiles[0].sha256, null);
+});
+
 test("inspector hashes one supported config without executing it and blocks multiples", async (t) => {
 	const root = await fixture(t, {
 		private: true,
@@ -161,6 +277,16 @@ test("inspector hashes one supported config without executing it and blocks mult
 	assert.ok(multiple.blockingReasons.includes("MULTIPLE_GENERATION_CONFIGS"));
 });
 
+test("inspector invalidates state when generation config bytes drift", async (t) => {
+	const root = await fixture(t);
+	await write(root, "openapi.config.ts", "export default {};\n");
+	const before = (await inspect(root)).value;
+	await write(root, "openapi.config.ts", "export default { changed: true };\n");
+	const after = (await inspect(root)).value;
+	assert.notEqual(after.generationConfig.files[0].sha256, before.generationConfig.files[0].sha256);
+	assert.notEqual(after.observedStateHash, before.observedStateHash);
+});
+
 test("inspector reports ignore state and conservative Codex modes without returning config bodies", async (t) => {
 	const root = await fixture(t, {
 		private: true,
@@ -175,6 +301,7 @@ test("inspector reports ignore state and conservative Codex modes without return
 	const { value, output } = await inspect(root);
 	assert.equal(value.runtimeState.directoryPresent, true);
 	assert.equal(value.runtimeState.ignored, true);
+	assert.match(value.runtimeState.gitignoreSha256, /^[a-f0-9]{64}$/);
 	assert.equal(value.codex.serverSectionCount, 1);
 	assert.equal(value.codex.inferredMode, "read-only");
 	assert.equal(value.codex.manualReviewRequired, true);
@@ -189,6 +316,24 @@ test("inspector reports ignore state and conservative Codex modes without return
 	assert.equal(unrelated.configPresent, true);
 	assert.equal(unrelated.serverSectionCount, 0);
 	assert.equal(unrelated.inferredMode, "missing");
+});
+
+test("inspector binds gitignore and Codex raw bytes even when diagnostics stay unchanged", async (t) => {
+	const root = await fixture(t);
+	await write(root, ".gitignore", "/.openapi-to/\n");
+	await write(root, ".codex/config.toml", "[mcp_servers.other]\ncommand = \"other\"\n");
+	const before = (await inspect(root)).value;
+
+	await write(root, ".gitignore", "/.openapi-to/\ndist/\n");
+	await write(root, ".codex/config.toml", "# unrelated comment\n[mcp_servers.other]\ncommand = \"other\"\n");
+	const after = (await inspect(root)).value;
+
+	assert.equal(after.runtimeState.ignored, true);
+	assert.equal(after.runtimeState.ignoreEvidence, before.runtimeState.ignoreEvidence);
+	assert.notEqual(after.runtimeState.gitignoreSha256, before.runtimeState.gitignoreSha256);
+	assert.equal(after.codex.inferredMode, before.codex.inferredMode);
+	assert.notEqual(after.codex.sha256, before.codex.sha256);
+	assert.notEqual(after.observedStateHash, before.observedStateHash);
 });
 
 test("inspector flags duplicate, absolute, and unsafe write-enabled Codex sections", async (t) => {

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -118,6 +118,14 @@ const REQUIRED_SETUP_EVALUATION_CASES = [
 	"approval-continue",
 	"approval-state-drift",
 ];
+const REQUIRED_SETUP_DEGRADED_CASES = new Map([
+	["degraded-package-json-missing", "block_without_install_plan"],
+	["degraded-package-json-drift-after-approval", "invalidate_setup_plan"],
+	["degraded-lockfile-drift-after-approval", "invalidate_setup_plan"],
+	["degraded-gitignore-drift-after-approval", "invalidate_setup_plan"],
+	["degraded-multiple-same-manager-lockfiles", "block_package_manager_conflict"],
+	["degraded-lockfile-too-large", "fail_closed_without_reading_contents"],
+]);
 const CONSUMER_OPERATION_EXAMPLE_FILES = [
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/SKILL.md`,
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/references/mcp-workflow.md`,
@@ -3012,6 +3020,12 @@ function validateOpenapiToSetupSkill(contents, failures) {
 		"approval_mode = \"prompt\"",
 		"manual review and do not overwrite or delete it",
 		"openapi-to-generate",
+		"`PACKAGE_JSON_MISSING`",
+		"`PACKAGE_MISSING` applies only when a valid `package.json` exists",
+		"raw-byte SHA-256",
+		"every lockfile's name, size, and bytes",
+		"Multiple actual lockfiles",
+		"Git status remains a separate pre-apply check",
 	]) {
 		if (!normalized.includes(marker)) failures.push(`${SETUP_SKILL_NAME} is missing required workflow marker ${marker}`);
 	}
@@ -3047,6 +3061,7 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 	else if (!trackedFiles.has(SETUP_SKILL_DOCUMENT)) failures.push(`setup Skill documentation is not tracked by Git: ${SETUP_SKILL_DOCUMENT}`);
 	else {
 		const document = await readFile(documentPath, "utf8");
+		const normalizedDocument = document.replace(/\s+/g, " ");
 		for (const marker of [
 			"openapi-to-setup",
 			"openapi-to-generate",
@@ -3059,8 +3074,49 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 			"Codex-first",
 			"pnpm",
 			"npm, Yarn, and Bun",
+			"`PACKAGE_JSON_MISSING`",
+			"`PACKAGE_MISSING` means a valid `package.json`",
+			"raw-byte SHA-256",
+			"Multiple actual lockfiles",
+			"new Setup Plan and `setupPlanId`",
+			"Git worktree status is re-read separately",
 		]) {
-			if (!document.includes(marker)) failures.push(`${SETUP_SKILL_DOCUMENT} is missing setup workflow marker ${marker}`);
+			if (!normalizedDocument.includes(marker)) failures.push(`${SETUP_SKILL_DOCUMENT} is missing setup workflow marker ${marker}`);
+		}
+	}
+
+	for (const [relativePath, markers] of [
+		[
+			"references/diagnosis.md",
+			[
+				"`PACKAGE_JSON_MISSING` and `BLOCKED`",
+				"`PACKAGE_MISSING` requires a valid manifest",
+				"manifest raw-byte hash",
+				"every detected lockfile name, size",
+				"`gitignoreSha256`",
+				"Codex config raw-byte hashes",
+				"Multiple actual lockfiles",
+				"`LOCKFILE_TOO_LARGE`",
+			],
+		],
+		[
+			"references/safe-writes.md",
+			[
+				"`PACKAGE_JSON_MISSING`",
+				"`PACKAGE_MISSING` is reserved for a trusted project with a valid manifest",
+				"raw-byte SHA-256 values for the manifest, every lockfile",
+				"new `setupPlanId`",
+				"Multiple actual lockfiles conflict",
+				"hash does not cover the whole worktree",
+			],
+		],
+	]) {
+		const contents = await readFile(join(root, SKILL_ROOT, SETUP_SKILL_NAME, relativePath), "utf8");
+		const normalizedContents = contents.replace(/\s+/g, " ");
+		for (const marker of markers) {
+			if (!normalizedContents.includes(marker)) {
+				failures.push(`${SKILL_ROOT}/${SETUP_SKILL_NAME}/${relativePath} is missing setup state-binding marker ${marker}`);
+			}
 		}
 	}
 
@@ -3094,6 +3150,19 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 	}
 	for (const id of REQUIRED_SETUP_EVALUATION_CASES) {
 		if (!ids.has(id)) failures.push(`${SETUP_SKILL_EVALUATION} is missing required case ${id}`);
+	}
+	const casesById = new Map(evaluation.cases.map((evaluationCase) => [evaluationCase?.id, evaluationCase]));
+	for (const [id, expected] of REQUIRED_SETUP_DEGRADED_CASES) {
+		const evaluationCase = casesById.get(id);
+		if (!evaluationCase) {
+			failures.push(`${SETUP_SKILL_EVALUATION} is missing required case ${id}`);
+			continue;
+		}
+		if (evaluationCase.category !== "degraded" || evaluationCase.expected !== expected) {
+			failures.push(
+				`${SETUP_SKILL_EVALUATION} case ${id} must be degraded with expected ${expected}`,
+			);
+		}
 	}
 }
 

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -1575,6 +1575,21 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			failure: /missing required workflow marker re-inspect, create a new plan and ID/,
 		},
 		{
+			path: ".agents/skills/openapi-to-setup/SKILL.md",
+			mutate: (contents) => contents.replace("`PACKAGE_JSON_MISSING`", "`PACKAGE_MISSING`"),
+			failure: /missing required workflow marker `PACKAGE_JSON_MISSING`/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/diagnosis.md",
+			mutate: (contents) => contents.replace("Multiple actual lockfiles", "Multiple manager types"),
+			failure: /missing setup state-binding marker Multiple actual lockfiles/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/safe-writes.md",
+			mutate: (contents) => contents.replace("new `setupPlanId`", "existing `setupPlanId`"),
+			failure: /missing setup state-binding marker new `setupPlanId`/,
+		},
+		{
 			path: ".agents/skills/openapi-to-setup/agents/openai.yaml",
 			mutate: (contents) => contents.replace("Diagnose and configure local openapi-to and Codex MCP", "Configure openapi-to"),
 			failure: /short_description must equal/,
@@ -1583,6 +1598,31 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
 			mutate: (contents) => contents.replace("degraded-count-schema-mismatch", "degraded-count-only"),
 			failure: /missing required case degraded-count-schema-mismatch/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) => contents.replace("degraded-package-json-missing", "degraded-manifest-absent"),
+			failure: /missing required case degraded-package-json-missing/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace(
+					"expected: block_package_manager_conflict",
+					"expected: infer_package_manager",
+				),
+			failure:
+				/case degraded-multiple-same-manager-lockfiles must be degraded with expected block_package_manager_conflict/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace(
+					"id: degraded-lockfile-too-large\n    category: degraded",
+					"id: degraded-lockfile-too-large\n    category: trigger",
+				),
+			failure:
+				/case degraded-lockfile-too-large must be degraded with expected fail_closed_without_reading_contents/,
 		},
 	];
 	for (const contractCase of cases) {


### PR DESCRIPTION
## Summary

- bind `observedStateHash` to raw `package.json` bytes, including invalid JSON
- stream every detected lockfile through SHA-256, record its size, enforce a 32 MiB limit, and fail closed on read, race, symlink, or root-boundary failures
- bind all `.gitignore` bytes while preserving the existing ignore diagnosis
- classify missing `package.json` as `BLOCKED` with `PACKAGE_JSON_MISSING`
- treat multiple actual lockfiles, including same-manager filename pairs, as `PACKAGE_MANAGER_CONFLICT`
- add drift, boundary, evaluation-matrix, documentation, and repository-contract coverage

## Safety and scope

The inspector keeps generation config and Codex config raw-byte hashes in the observation, does not return file bodies or absolute project roots, and continues to require a separate Git-status check before Apply. This does not bind the entire worktree.

Non-goals: no Phase 3 executor, setup CLI or MCP Tool, Host expansion, Core/plugin change, automatic npm/Yarn/Bun write, `openapi init` change, publication, or release operation.

## Validation

- PASS `node --check .agents/skills/openapi-to-setup/scripts/inspect-project.mjs`
- PASS `node --check .agents/skills/openapi-to-setup/scripts/hash-setup-plan.mjs`
- PASS `node --test scripts/openapi-to-setup.node-test.mjs` (22/22)
- PASS `pnpm verify:repository-contract`
- PASS `node --test scripts/repository-contract.node-test.mjs` (78/78)
- PASS `pnpm test:release-scripts` (163/163)
- PASS `pnpm lint:ci`
- PASS `pnpm lint:changed --base 09c2e9e66fae4e489cb557651b962e0d551b2930`
- PASS `pnpm verify:precommit` (build 11/11; Vitest 99 files passed, 657 tests passed, 2 skipped)
- PASS `git diff --check 09c2e9e66fae4e489cb557651b962e0d551b2930`

The first sandboxed precommit attempt could not bind localhost (`EPERM 127.0.0.1`); the same command passed when rerun with localhost access.

Mutation proof: temporarily disconnecting the manifest, lockfile, and `.gitignore` hashes caused all three targeted drift tests to fail. The mutation was restored and was not committed.

Dedicated recovery, performance, and stress suites were skipped because this change does not modify a runtime package, generated output, MCP writer, or release path. The required precommit suite still exercised the repository runtime tests.

## Review and release

- primary complete diff review: PASS
- independent P0/P1 review: `P0 = 0`, `P1 = 0`
- Changeset: omitted because this changes the repository-distributed consumer Skill and its repository contracts, not a versioned public npm package
