### PR TITLE
Complete portable setup inspection and Consumer Skill handoff

### DIFF
--- a/.agents/skills/openapi-to-generate/SKILL.md
+++ b/.agents/skills/openapi-to-generate/SKILL.md
@@ -71,8 +71,14 @@ If setup is missing, explain the exact gap and stop the affected workflow.
 `pnpm add -D openapi-to` is the recommended installation and
 `pnpm exec openapi-to-mcp` is the local MCP command, but this Skill must not run
 installation or modify `package.json`, `openapi.config.ts`, or
-`.codex/config.toml`. Setup automation belongs to a future `openapi-to-setup`
-Skill.
+`.codex/config.toml`. Hand those package, initialization, ignore, Host, restart,
+and capability-verification gaps to the existing `openapi-to-setup` Skill.
+Do not begin this workflow from `PACKAGE_MISSING`, `CONFIG_MISSING`,
+`HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`. `MCP_READ_ONLY`
+permits discovery, bounded contract reading, and operation-scoped Dry Run;
+Prepare/Apply additionally requires `MCP_WRITE_ENABLED` plus compatible current
+Schemas. `--allow-write` is not Setup Plan approval and is not generation Apply
+approval.
 
 ## 2. Discover the required Operation
 

--- a/.agents/skills/openapi-to-generate/SKILL.md
+++ b/.agents/skills/openapi-to-generate/SKILL.md
@@ -73,12 +73,16 @@ If setup is missing, explain the exact gap and stop the affected workflow.
 installation or modify `package.json`, `openapi.config.ts`, or
 `.codex/config.toml`. Hand those package, initialization, ignore, Host, restart,
 and capability-verification gaps to the existing `openapi-to-setup` Skill.
-Do not begin this workflow from `PACKAGE_MISSING`, `CONFIG_MISSING`,
-`HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`. `MCP_READ_ONLY`
-permits discovery, bounded contract reading, and operation-scoped Dry Run;
-Prepare/Apply additionally requires `MCP_WRITE_ENABLED` plus compatible current
-Schemas. `--allow-write` is not Setup Plan approval and is not generation Apply
-approval.
+
+Use this fail-closed handoff matrix:
+
+| Observed setup state | Generate handoff |
+| --- | --- |
+| `MCP_READ_ONLY` with compatible current Tool Schemas | Operation discovery, bounded contract reading, and operation-scoped Dry Run only. |
+| `MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas | The separately approval-bound Prepare/Apply workflow may also begin. |
+| Any other state | No Generate handoff; finish or repair setup first. |
+
+`--allow-write` is not Setup Plan approval and is not generation Apply approval.
 
 ## 2. Discover the required Operation
 

--- a/.agents/skills/openapi-to-generate/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-generate/references/evaluation-matrix.yaml
@@ -1,4 +1,5 @@
 schema_version: 1
+kind: static_skill_evaluation_inputs
 cases:
   - id: trigger-user-delete
     category: trigger
@@ -88,3 +89,35 @@ cases:
     category: degraded
     prompt: "Prepare 成功但 plan.applySupported 为 false"
     expected: stop_before_approval_and_apply
+  - id: degraded-tool-list-missing
+    category: degraded
+    prompt: "Host 声称 MCP 已连接，但无法取得实际 Tool 列表"
+    expected: fail_closed_without_operation_workflow
+  - id: degraded-old-tool-schema
+    category: degraded
+    prompt: "旧版本暴露同名 Tool，但 inputSchema 不支持当前选择参数"
+    expected: use_only_observed_schema_without_upgrade
+  - id: degraded-replace-unsupported
+    category: degraded
+    prompt: "用户明确要求 replace，但当前 Prepare Schema 只支持 add"
+    expected: reject_replace_without_emulation
+  - id: degraded-prepare-missing
+    category: degraded
+    prompt: "只读 Tool 可用，但 openapi_prepare_generation 不存在"
+    expected: remain_read_only_without_prepare
+  - id: degraded-apply-missing
+    category: degraded
+    prompt: "Prepare Tool 可见，但 openapi_apply_generation 不存在"
+    expected: stop_before_prepare_apply_workflow
+  - id: degraded-apply-token-expired
+    category: degraded
+    prompt: "已批准计划的 Apply token 已过期"
+    expected: reprepare_and_require_new_exact_approval
+  - id: degraded-plan-hash-drift
+    category: degraded
+    prompt: "用户批准的 planHash 与当前 Prepare 结果不一致"
+    expected: reject_apply_and_require_exact_current_hash
+  - id: degraded-setup-not-ready
+    category: degraded
+    prompt: "Setup 返回 PACKAGE_MISSING、CONFIG_MISSING、HOST_CONFIG_MISSING、RESTART_REQUIRED 或 BLOCKED"
+    expected: do_not_start_generate_workflow

--- a/.agents/skills/openapi-to-generate/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-generate/references/evaluation-matrix.yaml
@@ -121,3 +121,7 @@ cases:
     category: degraded
     prompt: "Setup 返回 PACKAGE_MISSING、CONFIG_MISSING、HOST_CONFIG_MISSING、RESTART_REQUIRED 或 BLOCKED"
     expected: do_not_start_generate_workflow
+  - id: degraded-setup-any-other-state
+    category: degraded
+    prompt: "Setup 返回 MCP_ANALYSIS_ONLY、任一尚未验证状态或未来新增状态"
+    expected: do_not_start_generate_for_unlisted_setup_state

--- a/.agents/skills/openapi-to-setup/SKILL.md
+++ b/.agents/skills/openapi-to-setup/SKILL.md
@@ -201,6 +201,19 @@ is verified, hand discovery and preview to `openapi-to-generate`; once
 write-enabled setup is verified, hand its controlled Prepare/Apply workflow to
 that Skill. Do not cross the restart boundary on the user's behalf.
 
+Use this fail-closed handoff matrix:
+
+| Observed setup state | Generate handoff |
+| --- | --- |
+| `PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED` | None; finish or repair setup first. |
+| `MCP_READ_ONLY` with compatible current Tool Schemas | Operation discovery, bounded contract preview, and operation-scoped Dry Run only. |
+| `MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas | The separately approval-bound Prepare/Apply workflow may also begin. |
+
+The presence of `--allow-write` is neither approval of the Setup Plan nor
+approval of a generation plan. Setup owns package/config/Host writes only;
+Generate owns Operation selection, generation Apply, and business-code
+integration only.
+
 ## Completion
 
 Report the requested and observed mode, state transitions, inspector hash,

--- a/.agents/skills/openapi-to-setup/SKILL.md
+++ b/.agents/skills/openapi-to-setup/SKILL.md
@@ -205,9 +205,9 @@ Use this fail-closed handoff matrix:
 
 | Observed setup state | Generate handoff |
 | --- | --- |
-| `PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED` | None; finish or repair setup first. |
-| `MCP_READ_ONLY` with compatible current Tool Schemas | Operation discovery, bounded contract preview, and operation-scoped Dry Run only. |
+| `MCP_READ_ONLY` with compatible current Tool Schemas | Operation discovery, bounded contract reading, and operation-scoped Dry Run only. |
 | `MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas | The separately approval-bound Prepare/Apply workflow may also begin. |
+| Any other state | No Generate handoff; finish or repair setup first. |
 
 The presence of `--allow-write` is neither approval of the Setup Plan nor
 approval of a generation plan. Setup owns package/config/Host writes only;

--- a/.agents/skills/openapi-to-setup/references/diagnosis.md
+++ b/.agents/skills/openapi-to-setup/references/diagnosis.md
@@ -79,6 +79,13 @@ not supply safe version evidence.
 - Lockfiles are hashed through the verified open file handle and limited to
   32 MiB. Oversized files produce `LOCKFILE_TOO_LARGE`; unreadable, replaced,
   symlinked, or out-of-root files fail closed without returning contents.
+- File reads use `O_RDONLY | O_NOFOLLOW` when Node exposes `O_NOFOLLOW`. On
+  Windows and other platforms without it, the inspector uses a verified
+  `O_RDONLY` fallback: it rejects an initial symlink or non-file, resolves the
+  real path inside the real project root, matches the opened file identity to
+  the entry, and validates identity and metadata again after reading. Bytes are
+  read only through the same `FileHandle`; a failed check remains `BLOCKED` and
+  never returns file contents.
 - An invalid/oversized package, config, ignore, or Codex metadata file is
   `BLOCKED`; do not truncate and proceed.
 - A symlink that resolves outside the real project root is `BLOCKED` and is not
@@ -89,3 +96,7 @@ not supply safe version evidence.
   restart. A Tool count is not Schema compatibility.
 - If the user requested diagnosis only, stop after reporting the state and do
   not prepare or apply writes.
+
+These checks narrow symlink and replacement races but are not an
+operating-system-level atomic snapshot. Re-check Git state and the exact
+`observedStateHash` before executing any Setup Plan.

--- a/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
@@ -159,6 +159,54 @@ cases:
     category: degraded
     prompt: "在 Windows Codex 项目中配置只读 MCP"
     expected: use_cmd_exe_template
+  - id: degraded-windows-no-nofollow
+    category: degraded
+    prompt: "Windows 的 Node fs.constants 没有 O_NOFOLLOW"
+    expected: use_verified_o_rdonly_fallback
+  - id: degraded-mcp-unavailable
+    category: degraded
+    prompt: "项目文件看起来完整，但当前 Host 无法连接 openapi_to MCP"
+    expected: diagnose_connection_without_generate_handoff
+  - id: degraded-tool-list-missing
+    category: degraded
+    prompt: "Host 声称 Server 已连接，但无法列出实际 Tool"
+    expected: block_capability_claim
+  - id: degraded-input-schema-not-visible
+    category: degraded
+    prompt: "Tool 名称可见，但相关 inputSchema 不可见"
+    expected: block_unverified_setup_handoff
+  - id: degraded-old-tool-schema
+    category: degraded
+    prompt: "本地旧版本暴露同名 Tool，但 Schema 不支持当前参数"
+    expected: use_only_observed_schema_without_upgrade
+  - id: degraded-config-drift-after-approval
+    category: degraded
+    prompt: "Setup Plan 批准后 generation config 字节发生变化"
+    expected: invalidate_setup_plan
+  - id: degraded-codex-drift-after-approval
+    category: degraded
+    prompt: "Setup Plan 批准后 .codex/config.toml 字节发生变化"
+    expected: invalidate_setup_plan
+  - id: degraded-handoff-config-missing
+    category: degraded
+    prompt: "状态是 CONFIG_MISSING，但请求直接搜索 Operation"
+    expected: finish_setup_before_generate
+  - id: degraded-handoff-host-config-missing
+    category: degraded
+    prompt: "状态是 HOST_CONFIG_MISSING，但请求直接运行 Dry Run"
+    expected: finish_setup_before_generate
+  - id: degraded-handoff-blocked
+    category: degraded
+    prompt: "状态是 BLOCKED，但请求继续 Generate 工作流"
+    expected: do_not_handoff_generate
+  - id: degraded-handoff-read-only
+    category: degraded
+    prompt: "状态是 MCP_READ_ONLY 且当前 Dry Run Schema 兼容"
+    expected: handoff_discovery_contract_and_dry_run_only
+  - id: degraded-handoff-write-enabled
+    category: degraded
+    prompt: "状态是 MCP_WRITE_ENABLED 且 Dry Run、Prepare、Apply Schema 均兼容"
+    expected: handoff_controlled_prepare_apply_with_separate_approval
 
   - id: approval-exact
     category: write-approval

--- a/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
+++ b/.agents/skills/openapi-to-setup/references/evaluation-matrix.yaml
@@ -207,6 +207,10 @@ cases:
     category: degraded
     prompt: "状态是 MCP_WRITE_ENABLED 且 Dry Run、Prepare、Apply Schema 均兼容"
     expected: handoff_controlled_prepare_apply_with_separate_approval
+  - id: degraded-handoff-any-other-state
+    category: degraded
+    prompt: "状态是 UNINSPECTED、PACKAGE_READY、CONFIG_READY、HOST_CONFIG_READY、MCP_ANALYSIS_ONLY 或未来新增状态"
+    expected: deny_generate_handoff_for_any_other_state
 
   - id: approval-exact
     category: write-approval

--- a/.agents/skills/openapi-to-setup/references/safe-writes.md
+++ b/.agents/skills/openapi-to-setup/references/safe-writes.md
@@ -76,6 +76,14 @@ actual lockfiles conflict even when they map to one manager. Lockfiles are
 streamed with a 32 MiB limit, and oversized, unreadable, symlinked, replaced, or
 out-of-root files fail closed without returning their contents.
 
+Inspector reads use `O_RDONLY | O_NOFOLLOW` where available. A platform without
+`O_NOFOLLOW` uses a verified `O_RDONLY` fallback that retains `lstat`, real-root,
+regular-file, opened-identity, and pre/post-read metadata checks. Contents are
+read only through the same `FileHandle`; the fallback does not authorize
+following symlinks or proceeding after identity uncertainty. These checks are
+not an operating-system-level atomic snapshot, so every approved Setup Plan
+still requires the fresh inspector hash and separate Git-state check above.
+
 ## Package install
 
 Only pnpm is automatically supported in this phase. Use the exact package and

--- a/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/inspect-project.mjs
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 
 import { createHash } from "node:crypto";
-import { constants } from "node:fs";
-import { lstat, open, realpath } from "node:fs/promises";
+import { lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import {
+	isInside,
+	openVerifiedFile,
+	unchangedDuringRead,
+} from "./secure-file-read.mjs";
 
 const SCHEMA_VERSION = 1;
 const MAX_FILE_BYTES = 128 * 1024;
@@ -52,37 +56,12 @@ function canonicalJson(value) {
 	return JSON.stringify(stable(value));
 }
 
-function isInside(root, candidate) {
-	const relative = path.relative(root, candidate);
-	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function openedEntryMatches(info, opened) {
-	return info.dev === opened.dev && info.ino === opened.ino;
-}
-
-function unchangedDuringRead(before, after) {
-	return (
-		before.dev === after.dev &&
-		before.ino === after.ino &&
-		before.size === after.size &&
-		before.mtimeMs === after.mtimeMs &&
-		before.ctimeMs === after.ctimeMs
-	);
-}
-
-function noFollowReadFlags() {
-	return Number.isInteger(constants.O_NOFOLLOW)
-		? constants.O_RDONLY | constants.O_NOFOLLOW
-		: undefined;
-}
-
 async function entryInfo(root, relativePath) {
 	const candidate = path.resolve(root, relativePath);
 	if (!isInside(root, candidate)) return { exists: false, unsafe: true };
 	let entry;
 	try {
-		entry = await lstat(candidate);
+		entry = await lstat(candidate, { bigint: true });
 	} catch (error) {
 		if (error?.code === "ENOENT" || error?.code === "ENOTDIR") {
 			return { exists: false, unsafe: false };
@@ -101,10 +80,9 @@ async function entryInfo(root, relativePath) {
 			symlink: entry.isSymbolicLink(),
 			isFile: entry.isFile(),
 			isDirectory: entry.isDirectory(),
-			size: entry.size,
-			dev: entry.dev,
-			ino: entry.ino,
+			stats: entry,
 			path: candidate,
+			realPath: resolved,
 		};
 	} catch (error) {
 		if (
@@ -118,37 +96,18 @@ async function entryInfo(root, relativePath) {
 	}
 }
 
-async function openVerifiedFile(info) {
-	const flags = noFollowReadFlags();
-	if (flags === undefined) return { readError: true };
-	let handle;
-	try {
-		handle = await open(info.path, flags);
-		const opened = await handle.stat();
-		if (!opened.isFile() || !openedEntryMatches(info, opened)) {
-			await handle.close();
-			return { unsafe: true };
-		}
-		return { handle, opened };
-	} catch (error) {
-		await handle?.close();
-		if (error?.code === "ELOOP") return { unsafe: true };
-		return { readError: true };
-	}
-}
-
 async function readBoundedText(root, relativePath) {
 	const info = await entryInfo(root, relativePath);
 	if (!info.exists || info.unsafe) return { info };
 	if (!info.isFile) return { info, readError: true };
-	const openedFile = await openVerifiedFile(info);
+	const openedFile = await openVerifiedFile(root, info);
 	if (!openedFile.handle) return { info: { ...info, unsafe: openedFile.unsafe === true }, readError: openedFile.readError === true };
 	const { handle, opened } = openedFile;
 	try {
-		if (opened.size > MAX_FILE_BYTES) return { info, tooLarge: true };
+		if (opened.size > BigInt(MAX_FILE_BYTES)) return { info, tooLarge: true };
 		const bytes = await handle.readFile();
-		const after = await handle.stat();
-		if (bytes.byteLength !== opened.size || !unchangedDuringRead(opened, after)) {
+		const after = await handle.stat({ bigint: true });
+		if (BigInt(bytes.byteLength) !== opened.size || !unchangedDuringRead(opened, after)) {
 			return { info, readError: true };
 		}
 		return { info, text: bytes.toString("utf8"), sha256: sha256(bytes) };
@@ -163,11 +122,17 @@ async function hashLockFile(root, relativePath) {
 	const info = await entryInfo(root, relativePath);
 	if (!info.exists || info.unsafe) return { info };
 	if (!info.isFile) return { info, readError: true };
-	const openedFile = await openVerifiedFile(info);
+	const openedFile = await openVerifiedFile(root, info);
 	if (!openedFile.handle) return { info: { ...info, unsafe: openedFile.unsafe === true }, readError: openedFile.readError === true };
 	const { handle, opened } = openedFile;
 	try {
-		if (opened.size > MAX_LOCKFILE_BYTES) return { info, size: opened.size, tooLarge: true };
+		if (opened.size > BigInt(MAX_LOCKFILE_BYTES)) {
+			return {
+				info,
+				size: opened.size <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(opened.size) : null,
+				tooLarge: true,
+			};
+		}
 		const hash = createHash("sha256");
 		let size = 0;
 		for await (const chunk of handle.createReadStream({ autoClose: false, start: 0 })) {
@@ -175,8 +140,8 @@ async function hashLockFile(root, relativePath) {
 			if (size > MAX_LOCKFILE_BYTES) return { info, size, tooLarge: true };
 			hash.update(chunk);
 		}
-		const after = await handle.stat();
-		if (size !== opened.size || !unchangedDuringRead(opened, after)) {
+		const after = await handle.stat({ bigint: true });
+		if (BigInt(size) !== opened.size || !unchangedDuringRead(opened, after)) {
 			return { info, size, readError: true };
 		}
 		return { info, size, sha256: hash.digest("hex") };

--- a/.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs
@@ -12,7 +12,12 @@ function isNonZero(value) {
 }
 
 function sameStatValues(left, right, fields) {
-	return fields.every((field) => left[field] === right[field]);
+	return fields.every(
+		(field) =>
+			isStatInteger(left?.[field]) &&
+			isStatInteger(right?.[field]) &&
+			left[field] === right[field],
+	);
 }
 
 function hasUsableIdentity(stats, platform) {

--- a/.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs
+++ b/.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs
@@ -1,0 +1,94 @@
+import { constants } from "node:fs";
+import { lstat, open, realpath } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+function isStatInteger(value) {
+	return typeof value === "bigint" || (Number.isInteger(value) && Number.isSafeInteger(value));
+}
+
+function isNonZero(value) {
+	return value !== 0 && value !== 0n;
+}
+
+function sameStatValues(left, right, fields) {
+	return fields.every((field) => left[field] === right[field]);
+}
+
+function hasUsableIdentity(stats, platform) {
+	if (!isStatInteger(stats?.dev) || !isStatInteger(stats?.ino) || !isNonZero(stats.ino)) return false;
+	return platform === "win32" || isNonZero(stats.dev);
+}
+
+export function isInside(root, candidate) {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function selectReadFlags({ readOnlyFlag, noFollowFlag }) {
+	if (!Number.isInteger(readOnlyFlag)) throw new TypeError("readOnlyFlag must be an integer");
+	return Number.isInteger(noFollowFlag) ? readOnlyFlag | noFollowFlag : readOnlyFlag;
+}
+
+export function sameOpenedFile(before, opened, platform = process.platform) {
+	if (!before?.isFile?.() || !opened?.isFile?.()) return false;
+	if (!hasUsableIdentity(before, platform) || !hasUsableIdentity(opened, platform)) return false;
+	if (before.dev !== opened.dev || before.ino !== opened.ino) return false;
+	if (platform !== "win32") return true;
+	return sameStatValues(before, opened, [
+		"size",
+		"birthtimeNs",
+		"ctimeNs",
+		"mtimeNs",
+		"mode",
+	]);
+}
+
+export function unchangedDuringRead(before, after, platform = process.platform) {
+	return (
+		sameOpenedFile(before, after, platform) &&
+		sameStatValues(before, after, [
+			"size",
+			"birthtimeNs",
+			"ctimeNs",
+			"mtimeNs",
+			"mode",
+			"nlink",
+		])
+	);
+}
+
+export async function openVerifiedFile(root, info, options = {}) {
+	const readOnlyFlag = Object.hasOwn(options, "readOnlyFlag")
+		? options.readOnlyFlag
+		: constants.O_RDONLY;
+	const noFollowFlag = Object.hasOwn(options, "noFollowFlag")
+		? options.noFollowFlag
+		: constants.O_NOFOLLOW;
+	const platform = options.platform ?? process.platform;
+	const flags = selectReadFlags({ readOnlyFlag, noFollowFlag });
+	let handle;
+	try {
+		handle = await open(info.path, flags);
+		const opened = await handle.stat({ bigint: true });
+		if (!sameOpenedFile(info.stats, opened, platform)) {
+			await handle.close();
+			return { unsafe: true };
+		}
+		const current = await lstat(info.path, { bigint: true });
+		if (current.isSymbolicLink() || !sameOpenedFile(current, opened, platform)) {
+			await handle.close();
+			return { unsafe: true };
+		}
+		const resolved = await realpath(info.path);
+		if (!isInside(root, resolved) || resolved !== info.realPath) {
+			await handle.close();
+			return { unsafe: true };
+		}
+		return { handle, opened };
+	} catch (error) {
+		await handle?.close();
+		if (error?.code === "ELOOP") return { unsafe: true };
+		return { readError: true };
+	}
+}

--- a/.github/workflows/a1-cross-platform.yml
+++ b/.github/workflows/a1-cross-platform.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Setup Node 20 and pnpm
         id: setup
         uses: ./.github/setup
+      - name: Run openapi-to setup inspector tests
+        run: node --test scripts/openapi-to-setup.node-test.mjs
       - name: Verify pnpm launcher
         run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id pnpm-launcher -- pnpm --version
       - name: Build packages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,14 @@ The high-level package map is:
 - `.agents/skills/` — the single authoritative source for repository Codex
   Skills.
 
+The two consumer Skills have exclusive write ownership. `openapi-to-setup`
+owns local aggregate-package, initialization, ignore, and project-level Codex
+configuration writes through exact Setup Plan approval.
+`openapi-to-generate` owns operation-scoped generation Apply and handwritten
+business integration through exact `planHash` approval. Historical Phase 2.1
+state binding and Phase 2.2 Windows portable reads harden Setup; they are not
+additional consumer Skills. A consuming project runs Setup before Generate.
+
 Package builds emit `dist/`; integration tests may create `test-output/`.
 Neither is source unless a tracked fixture explicitly says otherwise.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ upgrade an existing version, returns `RESTART_REQUIRED` after Host changes,
 and verifies actual Tools and inputSchema after restart. See the
 [setup Skill guide](docs/setup-skill.md).
 
+The phase numbers describe product delivery history, not invocation order:
+Phase 1 delivered `openapi-to-generate`; Phase 2 delivered
+`openapi-to-setup`; Phase 2.1 hardened Setup Plan state hashing; and Phase 2.2
+added portable verified reads for Windows without weakening POSIX
+`O_NOFOLLOW`. In a consuming project, always run setup first and hand off to
+generate only after the requested MCP state and current Tool Schemas are
+verified. Automatic setup writes currently cover pnpm and trusted project-level
+Codex `.codex/config.toml`; npm, Yarn, Bun, Claude Code, Cursor, and generic
+stdio Hosts remain diagnosis/manual-configuration boundaries.
+
 The first-phase `openapi-to-generate` Skill uses the consuming project's local `openapi-to` installation and
 checks both the actual MCP Tool list and current Tool inputSchema. Matching Tool
 names can expose different capabilities across versions: operation-scoped Dry

--- a/docs/agents/agents-and-skills-architecture.md
+++ b/docs/agents/agents-and-skills-architecture.md
@@ -26,6 +26,12 @@ validation, and the primary agent's complete diff review, non-trivial
 behavior-changing writes also use `independent-p0-p1-review` as a fresh,
 read-only review gate. Pure analysis does not load a write-oriented workflow.
 
+Consumer phase names describe delivery history: Phase 1 is Generate, Phase 2
+is Setup, Phase 2.1 is Setup state-hash hardening, and Phase 2.2 is Setup's
+Windows portable verified-read hardening. Phase 2.1 and Phase 2.2 are not
+additional Skills. The consuming-project execution order is Setup first,
+restart and verify current Tool Schemas, then Generate.
+
 ## Rule discovery boundary
 
 Agent discovery starts at the current repository root and uses

--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -108,15 +108,19 @@ Restart Codex after configuration or OpenAPI target changes. Use `/mcp` in the C
 
 See [getting started](./getting-started.md), [troubleshooting](./troubleshooting.md), and the shared [MCP security boundary](./mcp-security.md). The server is local stdio only. stdout is MCP JSON-RPC; operational logs use stderr. It does not provide HTTP, OAuth, multi-tenancy, LLM calls, or a chat UI.
 
-Once this trusted Server is available, the first-stage
+Once this trusted Server is available, the Phase 1
 [`openapi-to-generate` consumer Skill](./skills.md) gives Codex the bounded
 Operation discovery, operation-scoped Dry Run, exact-plan approval, Apply, and
 business integration sequence. It uses the consuming project's local
 openapi-to version, actual Tool list, and current Tool inputSchema; setup
-automation remains outside this stage. The second-stage
+automation remains outside this stage. The Phase 2
 [`openapi-to-setup` Skill](./setup-skill.md) owns that diagnosis and
 configuration boundary. It defaults to read-only, uses the existing
 `openapi init`, does not upgrade an existing version, requires an exact Setup
 Plan ID for writes, and returns `RESTART_REQUIRED` after changing this file.
 After restart it treats 3/8/10 only as orientation and verifies the actual Tool
 list, current Tool inputSchema, and returned capability fields.
+
+The phase labels are historical: Phase 2.1 hardened Setup state binding and
+Phase 2.2 added Windows portable verified reads. They are not new Skills, and
+the operational order remains Setup first, then Generate.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ pnpm exec openapi-to-mcp --help
 
 Advanced users who intentionally want only the MCP package boundary may instead install `pnpm add -D @openapi-to/mcp`; it provides the same standalone `openapi-to-mcp` command plus the `@openapi-to/mcp` and `@openapi-to/mcp/cli` programming interfaces.
 
-The first-stage consumer Skill is designed primarily for business projects
+The Phase 1 `openapi-to-generate` consumer Skill is designed primarily for business projects
 that install the aggregate `openapi-to` package. It does not automatically
 treat an MCP-only installation as a complete business code-generation
 environment; broader MCP-only consumer support is a separate design boundary.
@@ -81,15 +81,18 @@ Choose the Host-specific configuration:
 
 All Hosts share the same [security boundary](./mcp-security.md) and [troubleshooting guide](./troubleshooting.md).
 
-The second-stage [`openapi-to-setup` consumer Skill](./setup-skill.md) can
+The Phase 2 [`openapi-to-setup` consumer Skill](./setup-skill.md) can
 diagnose and configure an aggregate-package project and Codex MCP. It defaults
 to read-only, uses the existing `openapi init`, does not upgrade an existing
 version, and requires exact Setup Plan approval before package, init, ignore,
 or Host writes. Automatic package mutation is pnpm-only; npm, Yarn, and Bun are
 diagnostic/manual in this phase. A Codex config write returns
 `RESTART_REQUIRED` until restart and actual Tool/inputSchema verification.
+Phase 2.1 adds state-hash binding and Phase 2.2 adds Windows portable verified
+reads; these are Setup hardening, not separate Skills. Despite the historical
+phase numbering, consumers run Setup before Generate.
 
-After setup, a compatible AI Host can use the first-stage
+After setup, a compatible AI Host can use the Phase 1
 [`openapi-to-generate` consumer Skill](./skills.md) to discover
 Operations, preview operation-scoped output, preserve the Prepare/Apply
 approval boundary, and integrate generated code. The Skill orchestrates MCP;

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -6,6 +6,12 @@ Server. The first-phase `openapi-to-generate` Skill starts only after setup and
 handles API Operation discovery, selective generation, and business-code
 integration.
 
+These phase labels record delivery history. Phase 2.1 hardened Setup Plan
+state hashing, and Phase 2.2 added Windows portable verified reads; both are
+Setup hardening, not additional consumer Skills. The user journey still begins
+with Setup and proceeds to Generate only after restart and capability
+verification.
+
 Use setup for package installation, the existing `openapi init` flow,
 `/.openapi-to/` ignore repair, Codex project MCP configuration, startup
 diagnosis, and 3/8/10 Tool-mode validation. A vague setup request defaults to

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -37,6 +37,16 @@ the same manager—are a package-manager conflict. Oversized, unreadable,
 symlinked, replaced, or out-of-root lockfiles fail closed without returning
 their contents.
 
+On platforms that expose `O_NOFOLLOW`, verified reads use
+`O_RDONLY | O_NOFOLLOW`. Windows and other platforms without that constant use
+a verified `O_RDONLY` fallback; they do not drop the initial `lstat`, symlink,
+regular-file, real-root, or opened-file identity checks. All bytes are read
+through the same `FileHandle`, followed by another identity and metadata check.
+Any uncertainty remains `BLOCKED`. This is not an operating-system-level atomic
+snapshot, so Git status and `observedStateHash` are checked again before a Setup
+Plan executes. The focused Inspector suite runs in the repository's real
+Ubuntu, macOS, and Windows A1 CI matrix.
+
 ## Approval-bound writes
 
 Every package install, initializer run, ignore change, and Codex config change

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -129,12 +129,17 @@ modifies `package.json`, `openapi.config.ts`, or `.codex/config.toml`. Setup doe
 not add MCP Tools or replace MCP, and it hands daily API discovery, selective
 generation, and integration to generate after the requested mode is verified.
 
-The handoff fails closed. `PACKAGE_MISSING`, `CONFIG_MISSING`,
-`HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, and `BLOCKED` do not start Generate.
-`MCP_READ_ONLY` with compatible current Schemas permits Operation discovery,
-bounded contract reading, and operation-scoped Dry Run. Prepare/Apply requires
-`MCP_WRITE_ENABLED` plus compatible current Dry Run, Prepare, and Apply Schemas;
-`--allow-write` is neither Setup Plan approval nor generation Apply approval.
+The handoff follows one closed rule:
+
+| Observed setup state | Generate handoff |
+| --- | --- |
+| `MCP_READ_ONLY` with compatible current Tool Schemas | Operation discovery, bounded contract reading, and operation-scoped Dry Run only. |
+| `MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas | The separately approval-bound Prepare/Apply workflow may also begin. |
+| Any other state | No Generate handoff; finish or repair setup first. |
+
+This default-deny row includes `MCP_ANALYSIS_ONLY` and every pre-verification,
+blocked, or future state. `--allow-write` is neither Setup Plan approval nor
+generation Apply approval.
 
 Automatic setup support is limited to pnpm and trusted project-level Codex
 `.codex/config.toml`. npm, Yarn, Bun, Claude Code, Cursor, and generic stdio

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -8,6 +8,13 @@ by an AI Host.
 
 ## Two consumer phases
 
+The numbering records delivery history: Phase 1 is `openapi-to-generate`,
+Phase 2 is `openapi-to-setup`, Phase 2.1 is Setup state-hash hardening, and
+Phase 2.2 is Setup's Windows portable verified-read hardening. Phase 2.1 and
+Phase 2.2 do not add another consumer Skill. The runtime user path is the other
+way around: setup and verify the Host first, then hand the business request to
+generate.
+
 The repository ships two specialized consuming-project workflows:
 
 - [`openapi-to-setup`](../.agents/skills/openapi-to-setup/SKILL.md) diagnoses
@@ -121,3 +128,17 @@ The generate Skill remains phase one and never installs dependencies or
 modifies `package.json`, `openapi.config.ts`, or `.codex/config.toml`. Setup does
 not add MCP Tools or replace MCP, and it hands daily API discovery, selective
 generation, and integration to generate after the requested mode is verified.
+
+The handoff fails closed. `PACKAGE_MISSING`, `CONFIG_MISSING`,
+`HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, and `BLOCKED` do not start Generate.
+`MCP_READ_ONLY` with compatible current Schemas permits Operation discovery,
+bounded contract reading, and operation-scoped Dry Run. Prepare/Apply requires
+`MCP_WRITE_ENABLED` plus compatible current Dry Run, Prepare, and Apply Schemas;
+`--allow-write` is neither Setup Plan approval nor generation Apply approval.
+
+Automatic setup support is limited to pnpm and trusted project-level Codex
+`.codex/config.toml`. npm, Yarn, Bun, Claude Code, Cursor, and generic stdio
+Hosts can be diagnosed, but their writes remain manual. Neither Skill uses a
+global package fallback, silently upgrades openapi-to, executes an untrusted
+generation config during setup diagnosis, or treats Tool count as capability
+proof.

--- a/packages/mcp/scripts/run-test-group.mjs
+++ b/packages/mcp/scripts/run-test-group.mjs
@@ -66,7 +66,7 @@ const allVitestFiles = unique([...allMcpFiles, ...coreRecoveryFiles])
 
 const groups = {
   test: { build: 'write', files: allMcpFiles, expectedTests: 135, timeoutMs: 300_000 },
-  unit: { build: 'core', files: unitFiles, expectedTests: 81, timeoutMs: 120_000 },
+  unit: { build: 'core', files: unitFiles, expectedTests: 82, timeoutMs: 120_000 },
   integration: { build: 'write', files: integrationFiles, expectedTests: 54, timeoutMs: 240_000 },
   smoke: { build: 'write', files: smokeFiles, expectedTests: 6, scripts: crossPlatformSmokeScripts, timeoutMs: 120_000 },
   stdio: { build: 'write', files: stdioFiles, expectedTests: 48, timeoutMs: 240_000 },

--- a/packages/mcp/scripts/run-test-group.mjs
+++ b/packages/mcp/scripts/run-test-group.mjs
@@ -65,7 +65,7 @@ const e2eFiles = unique([...integrationFiles, ...coreRecoveryFiles])
 const allVitestFiles = unique([...allMcpFiles, ...coreRecoveryFiles])
 
 const groups = {
-  test: { build: 'write', files: allMcpFiles, expectedTests: 135, timeoutMs: 300_000 },
+  test: { build: 'write', files: allMcpFiles, expectedTests: 136, timeoutMs: 300_000 },
   unit: { build: 'core', files: unitFiles, expectedTests: 82, timeoutMs: 120_000 },
   integration: { build: 'write', files: integrationFiles, expectedTests: 54, timeoutMs: 240_000 },
   smoke: { build: 'write', files: smokeFiles, expectedTests: 6, scripts: crossPlatformSmokeScripts, timeoutMs: 120_000 },
@@ -74,7 +74,7 @@ const groups = {
   recovery: { build: 'write', files: recoveryFiles, expectedTests: 125, timeoutMs: 360_000 },
   performance: { build: 'mcp', files: [], expectedTests: 0, scripts: performanceScripts, timeoutMs: 360_000 },
   e2e: { build: 'write', files: e2eFiles, expectedTests: 108, scripts: crossPlatformSmokeScripts, timeoutMs: 480_000 },
-  all: { build: 'write', files: allVitestFiles, expectedTests: 189, scripts: [...crossPlatformSmokeScripts, ...performanceScripts], timeoutMs: 600_000 },
+  all: { build: 'write', files: allVitestFiles, expectedTests: 190, scripts: [...crossPlatformSmokeScripts, ...performanceScripts], timeoutMs: 600_000 },
 }
 
 function fail(message) {

--- a/packages/mcp/src/consumer-skill-contract.test.ts
+++ b/packages/mcp/src/consumer-skill-contract.test.ts
@@ -174,16 +174,39 @@ describe("openapi-to-generate Tool input examples", () => {
 		for (const example of examples) validateToolInputExample(example);
 	});
 
-	it("rejects an operation-scoped Dry Run example when its exact Target is removed", () => {
+	it("rejects Dry Run examples without exactly one Target and non-empty operations scope", () => {
 		const original = examples.find(
 			({ tool }) => tool === "openapi_generate_dry_run",
 		);
 		expect(original).toBeDefined();
-		const input = structuredClone(original?.input ?? {});
-		delete input.targets;
-		expect(() =>
-			validateToolInputExample({ ...(original as ToolInputExample), input }),
-		).toThrow(/must pass exactly one Target/);
+		for (const targets of [undefined, [], ["first", "second"]]) {
+			const input = structuredClone(original?.input ?? {});
+			if (targets === undefined) delete input.targets;
+			else input.targets = targets;
+			expect(() =>
+				validateToolInputExample({
+					...(original as ToolInputExample),
+					input,
+				}),
+			).toThrow(/must pass exactly one Target|does not match the current MCP inputSchema/);
+		}
+		for (const scope of [
+			{ type: "full" },
+			{ type: "operations", operationKeys: [] },
+		]) {
+			const input = {
+				...structuredClone(original?.input ?? {}),
+				scope,
+			};
+			expect(() =>
+				validateToolInputExample({
+					...(original as ToolInputExample),
+					input,
+				}),
+			).toThrow(
+				/must use operations scope with non-empty operationKeys|does not match the current MCP inputSchema/,
+			);
+		}
 	});
 
 	it("rejects fields that a non-strict production inputSchema would otherwise discard", () => {
@@ -225,9 +248,22 @@ describe("openapi-to-generate Tool input examples", () => {
 				input: extraAuthority,
 			}),
 		).toThrow(/does not match the current MCP inputSchema|unknown fields/);
+
+		for (const field of ["planId", "token"] as const) {
+			const wrongType = {
+				...structuredClone(original?.input ?? {}),
+				[field]: 123,
+			};
+			expect(() =>
+				validateToolInputExample({
+					...(original as ToolInputExample),
+					input: wrongType,
+				}),
+			).toThrow(/does not match the current MCP inputSchema/);
+		}
 	});
 
-	it("rejects an invalid replace example through the actual Prepare inputSchema", () => {
+	it("rejects Prepare examples without one Target or a supported non-empty selection", () => {
 		const original = examples.find(
 			({ tool, input }) =>
 				tool === "openapi_prepare_generation" &&
@@ -239,6 +275,28 @@ describe("openapi-to-generate Tool input examples", () => {
 		(input.selection as Record<string, unknown>).operationKeys = [];
 		expect(() =>
 			validateToolInputExample({ ...(original as ToolInputExample), input }),
+		).toThrow(/does not match the current MCP inputSchema/);
+
+		for (const targets of [[], ["first", "second"]]) {
+			const wrongTargetCount = {
+				...structuredClone(original?.input ?? {}),
+				targets,
+			};
+			expect(() =>
+				validateToolInputExample({
+					...(original as ToolInputExample),
+					input: wrongTargetCount,
+				}),
+			).toThrow(/must pass exactly one Target|does not match the current MCP inputSchema/);
+		}
+
+		const unsupportedSelection = structuredClone(original?.input ?? {});
+		(unsupportedSelection.selection as Record<string, unknown>).type = "remove";
+		expect(() =>
+			validateToolInputExample({
+				...(original as ToolInputExample),
+				input: unsupportedSelection,
+			}),
 		).toThrow(/does not match the current MCP inputSchema/);
 	});
 });

--- a/packages/mcp/src/consumer-skill-contract.test.ts
+++ b/packages/mcp/src/consumer-skill-contract.test.ts
@@ -144,6 +144,20 @@ function validateToolInputExample(example: ToolInputExample): void {
 			);
 		}
 	}
+
+	if (example.tool === "openapi_apply_generation") {
+		const fields = Object.keys(example.input).sort();
+		if (
+			!isDeepStrictEqual(fields, ["approvedPlanHash", "planId", "token"]) ||
+			typeof example.input.planId !== "string" ||
+			typeof example.input.token !== "string" ||
+			typeof example.input.approvedPlanHash !== "string"
+		) {
+			throw new Error(
+				`${location} must pass only the exact planId, token, and approvedPlanHash`,
+			);
+		}
+	}
 }
 
 describe("openapi-to-generate Tool input examples", () => {
@@ -184,6 +198,33 @@ describe("openapi-to-generate Tool input examples", () => {
 		expect(() =>
 			validateToolInputExample({ ...(original as ToolInputExample), input }),
 		).toThrow(/contains unknown fields/);
+	});
+
+	it("rejects Apply examples with missing plan binding or extra authority", () => {
+		const original = examples.find(
+			({ tool }) => tool === "openapi_apply_generation",
+		);
+		expect(original).toBeDefined();
+
+		const missingHash = structuredClone(original?.input ?? {});
+		delete missingHash.approvedPlanHash;
+		expect(() =>
+			validateToolInputExample({
+				...(original as ToolInputExample),
+				input: missingHash,
+			}),
+		).toThrow(/does not match the current MCP inputSchema/);
+
+		const extraAuthority = {
+			...structuredClone(original?.input ?? {}),
+			force: true,
+		};
+		expect(() =>
+			validateToolInputExample({
+				...(original as ToolInputExample),
+				input: extraAuthority,
+			}),
+		).toThrow(/does not match the current MCP inputSchema|unknown fields/);
 	});
 
 	it("rejects an invalid replace example through the actual Prepare inputSchema", () => {

--- a/scripts/openapi-to-setup.node-test.mjs
+++ b/scripts/openapi-to-setup.node-test.mjs
@@ -1,10 +1,18 @@
 import assert from "node:assert/strict";
 import { execFile, spawn } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, symlink, truncate, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import process from "node:process";
 import test from "node:test";
 import { promisify } from "node:util";
+import {
+	openVerifiedFile,
+	sameOpenedFile,
+	selectReadFlags,
+	unchangedDuringRead,
+} from "../.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs";
 
 const execFileAsync = promisify(execFile);
 const repositoryRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
@@ -28,6 +36,37 @@ async function inspect(root) {
 	const { stdout, stderr } = await execFileAsync(process.execPath, [inspector, "--root", root]);
 	assert.equal(stderr, "");
 	return { output: stdout, value: JSON.parse(stdout) };
+}
+
+async function createFileSymlink(t, target, linkPath) {
+	try {
+		await symlink(target, linkPath, "file");
+		return true;
+	} catch (error) {
+		if (
+			process.platform === "win32" &&
+			["EACCES", "EPERM"].includes(error?.code)
+		) {
+			t.skip(`Windows denied symlink creation (${error.code})`);
+			return false;
+		}
+		throw error;
+	}
+}
+
+function fakeStats(overrides = {}) {
+	return {
+		dev: 1n,
+		ino: 2n,
+		size: 12n,
+		birthtimeNs: 10n,
+		ctimeNs: 20n,
+		mtimeNs: 30n,
+		mode: 0o100644n,
+		nlink: 1n,
+		isFile: () => true,
+		...overrides,
+	};
 }
 
 function setupPlan(overrides = {}) {
@@ -71,6 +110,86 @@ function runWithInput(script, input) {
 		child.stdin.end(input);
 	});
 }
+
+test("secure reader selects O_NOFOLLOW when available and O_RDONLY otherwise", async (t) => {
+	assert.equal(
+		selectReadFlags({ readOnlyFlag: constants.O_RDONLY, noFollowFlag: 0x20000 }),
+		constants.O_RDONLY | 0x20000,
+	);
+	assert.equal(
+		selectReadFlags({ readOnlyFlag: constants.O_RDONLY, noFollowFlag: undefined }),
+		constants.O_RDONLY,
+	);
+
+	const root = await fixture(t);
+	const realRoot = await realpath(root);
+	const candidate = join(realRoot, "package.json");
+	const before = await lstat(candidate, { bigint: true });
+	const openedFile = await openVerifiedFile(
+		realRoot,
+		{
+			path: candidate,
+			realPath: await realpath(candidate),
+			stats: before,
+		},
+		{
+			readOnlyFlag: constants.O_RDONLY,
+			noFollowFlag: undefined,
+			platform: process.platform,
+		},
+	);
+	assert.ok(openedFile.handle);
+	try {
+		const bytes = await openedFile.handle.readFile();
+		const after = await openedFile.handle.stat({ bigint: true });
+		assert.match(bytes.toString("utf8"), /"private": true/);
+		assert.equal(unchangedDuringRead(openedFile.opened, after), true);
+	} finally {
+		await openedFile.handle.close();
+	}
+});
+
+test("secure reader rejects identity and read-stability mismatches deterministically", () => {
+	const before = fakeStats();
+	assert.equal(sameOpenedFile(before, fakeStats({ ino: 3n })), false);
+	assert.equal(unchangedDuringRead(before, fakeStats({ size: 13n })), false);
+	assert.equal(unchangedDuringRead(before, fakeStats({ mtimeNs: 31n })), false);
+
+	const windowsBefore = fakeStats({ dev: 0n });
+	assert.equal(sameOpenedFile(windowsBefore, fakeStats({ dev: 0n }), "win32"), true);
+	assert.equal(
+		sameOpenedFile(windowsBefore, fakeStats({ dev: 0n, ino: 0n }), "win32"),
+		false,
+	);
+});
+
+test("inspector hashes every bounded setup file without portable read failures", async (t) => {
+	const root = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0" },
+	});
+	await write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+	await write(root, ".gitignore", "/.openapi-to/\n");
+	await write(root, "openapi.config.ts", "export default {};\n");
+	await write(
+		root,
+		".codex/config.toml",
+		'[mcp_servers.openapi_to]\ncommand = "pnpm"\nargs = ["exec", "openapi-to-mcp", "--workspace-root", ".", "--config", "openapi.config.ts"]\n',
+	);
+	const { value } = await inspect(root);
+	assert.equal(value.state, "HOST_CONFIG_READY");
+	assert.equal(value.blockingReasons.some((reason) => reason.endsWith("_READ_FAILED")), false);
+	for (const digest of [
+		value.workspace.packageJson.sha256,
+		value.packageManager.lockFiles[0].sha256,
+		value.runtimeState.gitignoreSha256,
+		value.generationConfig.files[0].sha256,
+		value.codex.sha256,
+	]) {
+		assert.match(digest, /^[a-f0-9]{64}$/);
+	}
+});
 
 test("inspector reports a clean pnpm project with all setup capabilities missing", async (t) => {
 	const root = await fixture(t);
@@ -233,12 +352,21 @@ test("inspector blocks oversized lockfiles without loading their contents", asyn
 	assert.equal(value.packageManager.lockFiles[0].sha256, null);
 });
 
+test("inspector blocks a non-regular lockfile", async (t) => {
+	const root = await fixture(t);
+	await mkdir(join(root, "pnpm-lock.yaml"));
+	const { value } = await inspect(root);
+	assert.equal(value.state, "BLOCKED");
+	assert.ok(value.blockingReasons.includes("LOCKFILE_READ_FAILED"));
+	assert.equal(value.packageManager.lockFiles[0].sha256, null);
+});
+
 test("inspector does not follow a lockfile symlink outside the project", async (t) => {
 	const root = await fixture(t);
 	const outside = await mkdtemp(join(tmpdir(), "openapi-to-setup-lock-outside-"));
 	t.after(() => rm(outside, { recursive: true, force: true }));
 	await write(outside, "pnpm-lock.yaml", "external-lock-secret\n");
-	await symlink(join(outside, "pnpm-lock.yaml"), join(root, "pnpm-lock.yaml"));
+	if (!(await createFileSymlink(t, join(outside, "pnpm-lock.yaml"), join(root, "pnpm-lock.yaml")))) return;
 	const { value, output } = await inspect(root);
 	assert.equal(value.state, "BLOCKED");
 	assert.ok(value.blockingReasons.includes("LOCKFILE_OUTSIDE_ROOT"));
@@ -248,7 +376,7 @@ test("inspector does not follow a lockfile symlink outside the project", async (
 
 test("inspector fails closed on a dangling lockfile symlink", async (t) => {
 	const root = await fixture(t);
-	await symlink("missing-lock-target", join(root, "pnpm-lock.yaml"));
+	if (!(await createFileSymlink(t, "missing-lock-target", join(root, "pnpm-lock.yaml")))) return;
 	const { value } = await inspect(root);
 	assert.equal(value.state, "BLOCKED");
 	assert.ok(value.blockingReasons.includes("LOCKFILE_OUTSIDE_ROOT"));
@@ -373,6 +501,12 @@ test("inspector flags duplicate, absolute, and unsafe write-enabled Codex sectio
 	assert.equal(absoluteWindows.state, "BLOCKED");
 	assert.equal(absoluteWindows.codex.absolutePathDetected, true);
 
+	const uncWindowsRoot = await fixture(t);
+	await write(uncWindowsRoot, ".codex/config.toml", `[mcp_servers.openapi_to]\ncommand = "cmd.exe"\nargs = ["/d", "/s", "/c", "node \\\\server\\share\\openapi-to-mcp --workspace-root ."]\n`);
+	const uncWindows = (await inspect(uncWindowsRoot)).value;
+	assert.equal(uncWindows.state, "BLOCKED");
+	assert.equal(uncWindows.codex.absolutePathDetected, true);
+
 	const noncanonicalRoot = await fixture(t);
 	await write(noncanonicalRoot, ".codex/config.toml", `["mcp_servers"."openapi_to"]\ncommand = "pnpm"\n`);
 	const noncanonical = (await inspect(noncanonicalRoot)).value.codex;
@@ -385,7 +519,7 @@ test("inspector does not follow a supported config symlink outside the project",
 	const outside = await mkdtemp(join(tmpdir(), "openapi-to-setup-outside-"));
 	t.after(() => rm(outside, { recursive: true, force: true }));
 	await write(outside, "secret-config.ts", "export default 'do-not-read';\n");
-	await symlink(join(outside, "secret-config.ts"), join(root, "openapi.config.ts"));
+	if (!(await createFileSymlink(t, join(outside, "secret-config.ts"), join(root, "openapi.config.ts")))) return;
 	const { value, output } = await inspect(root);
 	assert.equal(value.state, "BLOCKED");
 	assert.ok(value.blockingReasons.includes("GENERATION_CONFIG_OUTSIDE_ROOT"));

--- a/scripts/openapi-to-setup.node-test.mjs
+++ b/scripts/openapi-to-setup.node-test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
 	openVerifiedFile,
@@ -15,7 +16,7 @@ import {
 } from "../.agents/skills/openapi-to-setup/scripts/secure-file-read.mjs";
 
 const execFileAsync = promisify(execFile);
-const repositoryRoot = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
+const repositoryRoot = fileURLToPath(new URL("..", import.meta.url));
 const inspector = join(repositoryRoot, ".agents/skills/openapi-to-setup/scripts/inspect-project.mjs");
 const hasher = join(repositoryRoot, ".agents/skills/openapi-to-setup/scripts/hash-setup-plan.mjs");
 
@@ -152,8 +153,11 @@ test("secure reader selects O_NOFOLLOW when available and O_RDONLY otherwise", a
 test("secure reader rejects identity and read-stability mismatches deterministically", () => {
 	const before = fakeStats();
 	assert.equal(sameOpenedFile(before, fakeStats({ ino: 3n })), false);
+	assert.equal(sameOpenedFile(before, fakeStats({ dev: undefined })), false);
+	assert.equal(sameOpenedFile(before, fakeStats({ ino: undefined })), false);
 	assert.equal(unchangedDuringRead(before, fakeStats({ size: 13n })), false);
 	assert.equal(unchangedDuringRead(before, fakeStats({ mtimeNs: 31n })), false);
+	assert.equal(unchangedDuringRead(before, fakeStats({ nlink: undefined })), false);
 
 	const windowsBefore = fakeStats({ dev: 0n });
 	assert.equal(sameOpenedFile(windowsBefore, fakeStats({ dev: 0n }), "win32"), true);
@@ -161,6 +165,12 @@ test("secure reader rejects identity and read-stability mismatches deterministic
 		sameOpenedFile(windowsBefore, fakeStats({ dev: 0n, ino: 0n }), "win32"),
 		false,
 	);
+	for (const field of ["size", "birthtimeNs", "ctimeNs", "mtimeNs", "mode"]) {
+		assert.equal(
+			sameOpenedFile(windowsBefore, fakeStats({ dev: 0n, [field]: undefined }), "win32"),
+			false,
+		);
+	}
 });
 
 test("inspector hashes every bounded setup file without portable read failures", async (t) => {
@@ -189,6 +199,50 @@ test("inspector hashes every bounded setup file without portable read failures",
 	]) {
 		assert.match(digest, /^[a-f0-9]{64}$/);
 	}
+});
+
+test("consumer fixture advances only through the setup states and binds every transition", async (t) => {
+	const root = await fixture(t, {
+		private: true,
+		packageManager: "pnpm@10.14.0",
+	});
+	const packageMissing = (await inspect(root)).value;
+	assert.equal(packageMissing.state, "PACKAGE_MISSING");
+
+	await write(root, "package.json", `${JSON.stringify({
+		private: true,
+		packageManager: "pnpm@10.14.0",
+		devDependencies: { "openapi-to": "4.2.0" },
+	}, null, 2)}\n`);
+	const configMissing = (await inspect(root)).value;
+	assert.equal(configMissing.state, "CONFIG_MISSING");
+	assert.notEqual(configMissing.observedStateHash, packageMissing.observedStateHash);
+
+	await write(root, "openapi.config.ts", "export default {};\n");
+	const hostMissing = (await inspect(root)).value;
+	assert.equal(hostMissing.state, "HOST_CONFIG_MISSING");
+	assert.notEqual(hostMissing.observedStateHash, configMissing.observedStateHash);
+
+	await write(
+		root,
+		".codex/config.toml",
+		'[mcp_servers.openapi_to]\ncommand = "pnpm"\nargs = ["exec", "openapi-to-mcp", "--workspace-root", ".", "--config", "openapi.config.ts"]\n',
+	);
+	const hostReady = (await inspect(root)).value;
+	assert.equal(hostReady.state, "HOST_CONFIG_READY");
+	assert.equal(hostReady.codex.inferredMode, "read-only");
+	assert.notEqual(hostReady.observedStateHash, hostMissing.observedStateHash);
+
+	await write(root, "openapi.config.ts", "export default { changed: true };\n");
+	const drifted = (await inspect(root)).value;
+	assert.equal(drifted.state, "HOST_CONFIG_READY");
+	assert.notEqual(drifted.observedStateHash, hostReady.observedStateHash);
+
+	const missingManifestRoot = await mkdtemp(join(tmpdir(), "openapi-to-setup-no-manifest-"));
+	t.after(() => rm(missingManifestRoot, { recursive: true, force: true }));
+	const blocked = (await inspect(missingManifestRoot)).value;
+	assert.equal(blocked.state, "BLOCKED");
+	assert.ok(blocked.blockingReasons.includes("PACKAGE_JSON_MISSING"));
 });
 
 test("inspector reports a clean pnpm project with all setup capabilities missing", async (t) => {

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -160,6 +160,10 @@ const REQUIRED_SETUP_DEGRADED_CASES = new Map([
 		"degraded-handoff-write-enabled",
 		"handoff_controlled_prepare_apply_with_separate_approval",
 	],
+	[
+		"degraded-handoff-any-other-state",
+		"deny_generate_handoff_for_any_other_state",
+	],
 ]);
 const CONSUMER_OPERATION_EXAMPLE_FILES = [
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/SKILL.md`,
@@ -203,6 +207,10 @@ const REQUIRED_CONSUMER_DEGRADED_CASES = new Map([
 		"reject_apply_and_require_exact_current_hash",
 	],
 	["degraded-setup-not-ready", "do_not_start_generate_workflow"],
+	[
+		"degraded-setup-any-other-state",
+		"do_not_start_generate_for_unlisted_setup_state",
+	],
 ]);
 export const EXPECTED_SKILL_ROLES = new Map([
 	["implement-and-review", "general-primary"],
@@ -2821,6 +2829,63 @@ function validateArchitectureDocument(contents, trackedSkills, failures) {
 	}
 }
 
+const FAIL_CLOSED_HANDOFF_ROWS = [
+	[
+		"`MCP_READ_ONLY` with compatible current Tool Schemas",
+		"Operation discovery, bounded contract reading, and operation-scoped Dry Run only.",
+	],
+	[
+		"`MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas",
+		"The separately approval-bound Prepare/Apply workflow may also begin.",
+	],
+	[
+		"Any other state",
+		"No Generate handoff; finish or repair setup first.",
+	],
+];
+
+function validateFailClosedHandoffMatrix(relativePath, contents, failures) {
+	const lines = contents.split(/\r?\n/);
+	const header = "| Observed setup state | Generate handoff |";
+	const headerIndexes = lines.flatMap((line, index) =>
+		line.trim() === header ? [index] : [],
+	);
+	if (headerIndexes.length !== 1) {
+		failures.push(
+			`${relativePath} must contain exactly one closed Generate handoff matrix`,
+		);
+		return;
+	}
+	const headerIndex = headerIndexes[0];
+	if (!/^\|\s*-+\s*\|\s*-+\s*\|$/.test(lines[headerIndex + 1]?.trim() ?? "")) {
+		failures.push(`${relativePath} Generate handoff matrix has an invalid header separator`);
+		return;
+	}
+	const rows = [];
+	for (const line of lines.slice(headerIndex + 2)) {
+		const trimmed = line.trim();
+		if (!trimmed.startsWith("|")) break;
+		const cells = trimmed
+			.slice(1, trimmed.endsWith("|") ? -1 : undefined)
+			.split("|")
+			.map((cell) => cell.trim());
+		rows.push(cells);
+	}
+	if (
+		rows.length !== FAIL_CLOSED_HANDOFF_ROWS.length ||
+		rows.some(
+			(row, index) =>
+				row.length !== 2 ||
+				row[0] !== FAIL_CLOSED_HANDOFF_ROWS[index][0] ||
+				row[1] !== FAIL_CLOSED_HANDOFF_ROWS[index][1],
+		)
+	) {
+		failures.push(
+			`${relativePath} Generate handoff matrix must allow only verified read-only and write-enabled states, then deny any other state`,
+		);
+	}
+}
+
 function validateOpenapiToGenerateSkill(contents, failures) {
 	let metadata;
 	try {
@@ -2854,9 +2919,7 @@ function validateOpenapiToGenerateSkill(contents, failures) {
 		"Tool existence and Tool count do not prove",
 		"Never silently substitute a global installation",
 		"existing `openapi-to-setup` Skill",
-		"`PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`",
-		"`MCP_READ_ONLY` permits discovery",
-		"Prepare/Apply additionally requires `MCP_WRITE_ENABLED`",
+		"Use this fail-closed handoff matrix:",
 		"`--allow-write` is not Setup Plan approval",
 		"pnpm add -D openapi-to",
 		"pnpm exec openapi-to-mcp",
@@ -2897,6 +2960,11 @@ function validateOpenapiToGenerateSkill(contents, failures) {
 			`${CONSUMER_SKILL_NAME} must prohibit automatic installation and setup mutation`,
 		);
 	}
+	validateFailClosedHandoffMatrix(
+		`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/SKILL.md`,
+		contents,
+		failures,
+	);
 }
 
 function validateOperationScopedDryRunExamples(
@@ -3036,6 +3104,11 @@ async function validateOpenapiToGenerateFiles(
 				`${CONSUMER_SKILL_DOCUMENT} must not use legacy config path ${legacyConfigPath}`,
 			);
 		}
+		validateFailClosedHandoffMatrix(
+			CONSUMER_SKILL_DOCUMENT,
+			documentContents,
+			failures,
+		);
 	}
 	if (skillContents?.includes(legacyConfigPath)) {
 		failures.push(
@@ -3203,14 +3276,17 @@ function validateOpenapiToSetupSkill(contents, failures) {
 		"every lockfile's name, size, and bytes",
 		"Multiple actual lockfiles",
 		"Git status remains a separate pre-apply check",
-		"`PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`",
-		"`MCP_READ_ONLY` with compatible current Tool Schemas",
-		"`MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas",
+		"Use this fail-closed handoff matrix:",
 		"Setup owns package/config/Host writes only",
 		"Generate owns Operation selection, generation Apply, and business-code integration only",
 	]) {
 		if (!normalized.includes(marker)) failures.push(`${SETUP_SKILL_NAME} is missing required workflow marker ${marker}`);
 	}
+	validateFailClosedHandoffMatrix(
+		`${SKILL_ROOT}/${SETUP_SKILL_NAME}/SKILL.md`,
+		contents,
+		failures,
+	);
 	if (contents.includes(".OpenAPI/openapi.config.ts")) {
 		failures.push(`${SETUP_SKILL_NAME} must not use legacy config path .OpenAPI/openapi.config.ts`);
 	}

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -95,6 +95,7 @@ const SETUP_SKILL_REQUIRED_FILES = [
 	"references/safe-writes.md",
 	"references/evaluation-matrix.yaml",
 	"scripts/inspect-project.mjs",
+	"scripts/secure-file-read.mjs",
 	"scripts/hash-setup-plan.mjs",
 ];
 const SETUP_EVALUATION_MINIMUMS = new Map([
@@ -3161,6 +3162,9 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 			"Multiple actual lockfiles",
 			"new Setup Plan and `setupPlanId`",
 			"Git worktree status is re-read separately",
+			"verified `O_RDONLY` fallback",
+			"same `FileHandle`",
+			"operating-system-level atomic snapshot",
 		]) {
 			if (!normalizedDocument.includes(marker)) failures.push(`${SETUP_SKILL_DOCUMENT} is missing setup workflow marker ${marker}`);
 		}
@@ -3178,6 +3182,9 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 				"Codex config raw-byte hashes",
 				"Multiple actual lockfiles",
 				"`LOCKFILE_TOO_LARGE`",
+				"`O_NOFOLLOW`",
+				"verified `O_RDONLY` fallback",
+				"same `FileHandle`",
 			],
 		],
 		[
@@ -3189,6 +3196,8 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 				"new `setupPlanId`",
 				"Multiple actual lockfiles conflict",
 				"hash does not cover the whole worktree",
+				"verified `O_RDONLY` fallback",
+				"same `FileHandle`",
 			],
 		],
 	]) {
@@ -3197,6 +3206,52 @@ async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByNa
 		for (const marker of markers) {
 			if (!normalizedContents.includes(marker)) {
 				failures.push(`${SKILL_ROOT}/${SETUP_SKILL_NAME}/${relativePath} is missing setup state-binding marker ${marker}`);
+			}
+		}
+	}
+
+	const inspectorPath = join(
+		root,
+		SKILL_ROOT,
+		SETUP_SKILL_NAME,
+		"scripts/inspect-project.mjs",
+	);
+	const secureReaderPath = join(
+		root,
+		SKILL_ROOT,
+		SETUP_SKILL_NAME,
+		"scripts/secure-file-read.mjs",
+	);
+	if ((await exists(inspectorPath)) && (await exists(secureReaderPath))) {
+		const inspector = await readFile(inspectorPath, "utf8");
+		const secureReader = await readFile(secureReaderPath, "utf8");
+		for (const marker of [
+			"selectReadFlags",
+			"Number.isInteger(noFollowFlag)",
+			": readOnlyFlag;",
+			"sameOpenedFile",
+			"unchangedDuringRead",
+			"lstat(info.path, { bigint: true })",
+			"realpath(info.path)",
+			"handle.stat({ bigint: true })",
+		]) {
+			if (!secureReader.includes(marker)) {
+				failures.push(`setup secure reader is missing portable safety marker ${marker}`);
+			}
+		}
+		if (!inspector.includes('from "./secure-file-read.mjs"')) {
+			failures.push("setup inspector must use the portable secure reader");
+		}
+		if (inspector.includes("if (flags === undefined)")) {
+			failures.push("setup inspector must not fail every read when O_NOFOLLOW is unavailable");
+		}
+		for (const forbidden of [
+			"OPENAPI_TO_DISABLE_NOFOLLOW",
+			"--unsafe-no-follow",
+			"--skip-file-identity-check",
+		]) {
+			if (inspector.includes(forbidden) || secureReader.includes(forbidden)) {
+				failures.push(`setup secure reader exposes forbidden safety override ${forbidden}`);
 			}
 		}
 	}
@@ -3864,6 +3919,7 @@ export async function auditCiDiagnosticsContracts(root = repositoryRoot) {
 			"pnpm exec openapi-to-mcp --help",
 			"packages/openapi/bin/openapi-to-mcp.js --help",
 			"packages/mcp/bin/openapi-to-mcp.js --help",
+			"node --test scripts/openapi-to-setup.node-test.mjs",
 		]) {
 			if (!a1.includes(required)) {
 				failures.push(
@@ -4264,6 +4320,8 @@ export async function auditRepositoryContracts(root = repositoryRoot) {
 			"packages/mcp/bin/openapi-to-mcp.js",
 			"actions/upload-artifact@v4",
 			"A1_TEST_ARTIFACT_DIR",
+			"name: Run openapi-to setup inspector tests",
+			"run: node --test scripts/openapi-to-setup.node-test.mjs",
 		]) {
 			if (!a1Workflow.includes(required))
 				failures.push(`A1 workflow is missing ${required}`);

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -85,6 +85,13 @@ const ARCHITECTURE_DOCUMENT = "docs/agents/agents-and-skills-architecture.md";
 const CONSUMER_SKILL_NAME = "openapi-to-generate";
 const CONSUMER_SKILL_DOCUMENT = "docs/skills.md";
 const CONSUMER_SKILL_EVALUATION = `${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/references/evaluation-matrix.yaml`;
+const CONSUMER_SKILL_REQUIRED_FILES = [
+	"SKILL.md",
+	"agents/openai.yaml",
+	"references/mcp-workflow.md",
+	"references/controlled-write.md",
+	"references/evaluation-matrix.yaml",
+];
 const SETUP_SKILL_NAME = "openapi-to-setup";
 const SETUP_SKILL_DOCUMENT = "docs/setup-skill.md";
 const SETUP_SKILL_EVALUATION = `${SKILL_ROOT}/${SETUP_SKILL_NAME}/references/evaluation-matrix.yaml`;
@@ -124,8 +131,35 @@ const REQUIRED_SETUP_DEGRADED_CASES = new Map([
 	["degraded-package-json-drift-after-approval", "invalidate_setup_plan"],
 	["degraded-lockfile-drift-after-approval", "invalidate_setup_plan"],
 	["degraded-gitignore-drift-after-approval", "invalidate_setup_plan"],
+	["degraded-config-drift-after-approval", "invalidate_setup_plan"],
+	["degraded-codex-drift-after-approval", "invalidate_setup_plan"],
 	["degraded-multiple-same-manager-lockfiles", "block_package_manager_conflict"],
 	["degraded-lockfile-too-large", "fail_closed_without_reading_contents"],
+	["degraded-windows-no-nofollow", "use_verified_o_rdonly_fallback"],
+	[
+		"degraded-mcp-unavailable",
+		"diagnose_connection_without_generate_handoff",
+	],
+	["degraded-tool-list-missing", "block_capability_claim"],
+	[
+		"degraded-input-schema-not-visible",
+		"block_unverified_setup_handoff",
+	],
+	["degraded-old-tool-schema", "use_only_observed_schema_without_upgrade"],
+	["degraded-handoff-config-missing", "finish_setup_before_generate"],
+	[
+		"degraded-handoff-host-config-missing",
+		"finish_setup_before_generate",
+	],
+	["degraded-handoff-blocked", "do_not_handoff_generate"],
+	[
+		"degraded-handoff-read-only",
+		"handoff_discovery_contract_and_dry_run_only",
+	],
+	[
+		"degraded-handoff-write-enabled",
+		"handoff_controlled_prepare_apply_with_separate_approval",
+	],
 ]);
 const CONSUMER_OPERATION_EXAMPLE_FILES = [
 	`${SKILL_ROOT}/${CONSUMER_SKILL_NAME}/SKILL.md`,
@@ -133,6 +167,9 @@ const CONSUMER_OPERATION_EXAMPLE_FILES = [
 	CONSUMER_SKILL_DOCUMENT,
 ];
 const REQUIRED_CONSUMER_DEGRADED_CASES = new Map([
+	["degraded-server-absent", "fail_closed_explain_server_setup"],
+	["degraded-tool-list-missing", "fail_closed_without_operation_workflow"],
+	["degraded-old-tool-schema", "use_only_observed_schema_without_upgrade"],
 	[
 		"degraded-multiple-targets-require-exact-target",
 		"list_targets_and_pass_one_exact_target",
@@ -154,6 +191,18 @@ const REQUIRED_CONSUMER_DEGRADED_CASES = new Map([
 		"degraded-prepare-not-applyable",
 		"stop_before_approval_and_apply",
 	],
+	["degraded-replace-unsupported", "reject_replace_without_emulation"],
+	["degraded-prepare-missing", "remain_read_only_without_prepare"],
+	["degraded-apply-missing", "stop_before_prepare_apply_workflow"],
+	[
+		"degraded-apply-token-expired",
+		"reprepare_and_require_new_exact_approval",
+	],
+	[
+		"degraded-plan-hash-drift",
+		"reject_apply_and_require_exact_current_hash",
+	],
+	["degraded-setup-not-ready", "do_not_start_generate_workflow"],
 ]);
 export const EXPECTED_SKILL_ROLES = new Map([
 	["implement-and-review", "general-primary"],
@@ -2804,6 +2853,11 @@ function validateOpenapiToGenerateSkill(contents, failures) {
 		"current Tool inputSchema",
 		"Tool existence and Tool count do not prove",
 		"Never silently substitute a global installation",
+		"existing `openapi-to-setup` Skill",
+		"`PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`",
+		"`MCP_READ_ONLY` permits discovery",
+		"Prepare/Apply additionally requires `MCP_WRITE_ENABLED`",
+		"`--allow-write` is not Setup Plan approval",
 		"pnpm add -D openapi-to",
 		"pnpm exec openapi-to-mcp",
 		"openapi.config.ts",
@@ -2897,12 +2951,52 @@ function validateOpenapiToGenerateInterface(metadata, relativePath, failures) {
 	}
 }
 
+async function validateConsumerSkillDistribution(
+	root,
+	trackedFiles,
+	skillName,
+	requiredFiles,
+	failures,
+) {
+	const prefix = `${SKILL_ROOT}/${skillName}/`;
+	for (const relativeFile of requiredFiles) {
+		const relativePath = `${prefix}${relativeFile}`;
+		if (!(await exists(join(root, relativePath)))) {
+			failures.push(`missing consumer Skill file ${relativePath}`);
+		} else if (!trackedFiles.has(relativePath)) {
+			failures.push(`consumer Skill file is not tracked by Git: ${relativePath}`);
+		}
+	}
+	for (const relativePath of [...trackedFiles].filter((file) =>
+		file.startsWith(prefix),
+	)) {
+		if (/(?:^|\/)(?:tmp|temp)(?:\/|$)|\.(?:bak|orig|rej|tmp)$/i.test(relativePath)) {
+			failures.push(`consumer Skill distribution contains temporary file ${relativePath}`);
+			continue;
+		}
+		const contents = await readFile(join(root, relativePath), "utf8");
+		if (/\/Users\/[^/]+\/|\/home\/[^/]+\/|[A-Za-z]:\\(?:Users|Documents)\\/.test(contents)) {
+			failures.push(`consumer Skill distribution contains an absolute machine path in ${relativePath}`);
+		}
+		if (/-----BEGIN [A-Z ]*PRIVATE KEY-----|\bgh[opsu]_[A-Za-z0-9]{20,}|\bnpm_[A-Za-z0-9]{20,}/.test(contents)) {
+			failures.push(`consumer Skill distribution contains credential-like test data in ${relativePath}`);
+		}
+	}
+}
+
 async function validateOpenapiToGenerateFiles(
 	root,
 	trackedFiles,
 	skillContentsByName,
 	failures,
 ) {
+	await validateConsumerSkillDistribution(
+		root,
+		trackedFiles,
+		CONSUMER_SKILL_NAME,
+		CONSUMER_SKILL_REQUIRED_FILES,
+		failures,
+	);
 	const skillContents = skillContentsByName.get(CONSUMER_SKILL_NAME);
 	if (skillContents) validateOpenapiToGenerateSkill(skillContents, failures);
 
@@ -2983,10 +3077,11 @@ async function validateOpenapiToGenerateFiles(
 	if (
 		!isMapping(evaluation) ||
 		evaluation.schema_version !== 1 ||
+		evaluation.kind !== "static_skill_evaluation_inputs" ||
 		!Array.isArray(evaluation.cases)
 	) {
 		failures.push(
-			`${CONSUMER_SKILL_EVALUATION} must contain schema_version 1 and a cases array`,
+			`${CONSUMER_SKILL_EVALUATION} must contain schema_version 1, static kind, and a cases array`,
 		);
 		return;
 	}
@@ -3108,6 +3203,11 @@ function validateOpenapiToSetupSkill(contents, failures) {
 		"every lockfile's name, size, and bytes",
 		"Multiple actual lockfiles",
 		"Git status remains a separate pre-apply check",
+		"`PACKAGE_MISSING`, `CONFIG_MISSING`, `HOST_CONFIG_MISSING`, `RESTART_REQUIRED`, or `BLOCKED`",
+		"`MCP_READ_ONLY` with compatible current Tool Schemas",
+		"`MCP_WRITE_ENABLED` with compatible current Dry Run, Prepare, and Apply Schemas",
+		"Setup owns package/config/Host writes only",
+		"Generate owns Operation selection, generation Apply, and business-code integration only",
 	]) {
 		if (!normalized.includes(marker)) failures.push(`${SETUP_SKILL_NAME} is missing required workflow marker ${marker}`);
 	}
@@ -3130,6 +3230,13 @@ function validateOpenapiToSetupInterface(metadata, relativePath, failures) {
 }
 
 async function validateOpenapiToSetupFiles(root, trackedFiles, skillContentsByName, failures) {
+	await validateConsumerSkillDistribution(
+		root,
+		trackedFiles,
+		SETUP_SKILL_NAME,
+		["SKILL.md", ...SETUP_SKILL_REQUIRED_FILES],
+		failures,
+	);
 	const skillContents = skillContentsByName.get(SETUP_SKILL_NAME);
 	if (skillContents) validateOpenapiToSetupSkill(skillContents, failures);
 	for (const relativeFile of SETUP_SKILL_REQUIRED_FILES) {

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -303,6 +303,7 @@ async function createContractFixture(t) {
 		"references/safe-writes.md",
 		"references/evaluation-matrix.yaml",
 		"scripts/inspect-project.mjs",
+		"scripts/secure-file-read.mjs",
 		"scripts/hash-setup-plan.mjs",
 	]) {
 		await writeFixtureFile(
@@ -451,6 +452,8 @@ test("blocking Actions workflows use controlled fixtures and retain diagnostic a
 	assert.match(a1, /fail-fast:\s*false/);
 	assert.match(a1, /working-directory:\s*e2e\/common/);
 	assert.match(a1, /actions\/upload-artifact@v4/);
+	assert.match(a1, /name:\s*Run openapi-to setup inspector tests/);
+	assert.match(a1, /run:\s*node --test scripts\/openapi-to-setup\.node-test\.mjs/);
 	assert.doesNotMatch(e2e, /petstore\.swagger\.io/);
 	assert.doesNotMatch(e2e, /fail-fast:\s*true/);
 	assert.match(e2e, /pnpm test:e2e:remote/);
@@ -1604,6 +1607,16 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			failure: /missing setup state-binding marker new `setupPlanId`/,
 		},
 		{
+			path: ".agents/skills/openapi-to-setup/scripts/secure-file-read.mjs",
+			mutate: (contents) => contents.replace(": readOnlyFlag;", ": undefined;"),
+			failure: /missing portable safety marker : readOnlyFlag;/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/scripts/secure-file-read.mjs",
+			mutate: (contents) => `${contents}\n// --unsafe-no-follow\n`,
+			failure: /exposes forbidden safety override --unsafe-no-follow/,
+		},
+		{
 			path: ".agents/skills/openapi-to-setup/agents/openai.yaml",
 			mutate: (contents) => contents.replace("Diagnose and configure local openapi-to and Codex MCP", "Configure openapi-to"),
 			failure: /short_description must equal/,
@@ -1650,6 +1663,13 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 	assertFailure(
 		await auditAgentAndSkillContracts(missingScriptRoot),
 		/setup Skill file is not tracked by Git: .*inspect-project\.mjs/,
+	);
+
+	const missingHelperRoot = await createContractFixture(t);
+	await git(missingHelperRoot, "rm", "--cached", "--", ".agents/skills/openapi-to-setup/scripts/secure-file-read.mjs");
+	assertFailure(
+		await auditAgentAndSkillContracts(missingHelperRoot),
+		/setup Skill file is not tracked by Git: .*secure-file-read\.mjs/,
 	);
 });
 

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -1515,8 +1515,15 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 		},
 		{
 			path: ".agents/skills/openapi-to-generate/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace("kind: static_skill_evaluation_inputs\n", ""),
+			failure: /must contain schema_version 1, static kind, and a cases array/,
+		},
+		{
+			path: ".agents/skills/openapi-to-generate/references/evaluation-matrix.yaml",
 			mutate: (contents) => {
-				let replacements = 7;
+				let replacements =
+					(contents.match(/category: degraded/g) ?? []).length - 3;
 				return contents.replaceAll("category: degraded", (category) => {
 					if (replacements === 0) return category;
 					replacements -= 1;
@@ -1533,6 +1540,15 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 					"degraded-schema-hidden",
 				),
 			failure: /missing required case degraded-schema-not-visible/,
+		},
+		{
+			path: ".agents/skills/openapi-to-generate/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace(
+					"degraded-apply-token-expired",
+					"degraded-apply-token-old",
+				),
+			failure: /missing required case degraded-apply-token-expired/,
 		},
 	];
 	for (const contractCase of cases) {
@@ -1571,6 +1587,19 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 	assertFailure(
 		await auditAgentAndSkillContracts(missingReferenceRoot),
 		/references missing path references\/missing-workflow\.md/,
+	);
+
+	const missingDistributionFileRoot = await createContractFixture(t);
+	await git(
+		missingDistributionFileRoot,
+		"rm",
+		"--cached",
+		"--",
+		".agents/skills/openapi-to-generate/references/controlled-write.md",
+	);
+	assertFailure(
+		await auditAgentAndSkillContracts(missingDistributionFileRoot),
+		/consumer Skill file is not tracked by Git: .*controlled-write\.md/,
 	);
 });
 
@@ -1630,6 +1659,11 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
 			mutate: (contents) => contents.replace("degraded-package-json-missing", "degraded-manifest-absent"),
 			failure: /missing required case degraded-package-json-missing/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) => contents.replace("degraded-windows-no-nofollow", "degraded-windows-portable-read"),
+			failure: /missing required case degraded-windows-no-nofollow/,
 		},
 		{
 			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -1499,6 +1499,13 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 			failure: /missing required workflow marker Tool existence and Tool count do not prove/,
 		},
 		{
+			path: ".agents/skills/openapi-to-generate/SKILL.md",
+			mutate: (contents) =>
+				contents.replace("| Any other state |", "| `MCP_ANALYSIS_ONLY` |"),
+			failure:
+				/must allow only verified read-only and write-enabled states, then deny any other state/,
+		},
+		{
 			path: ".agents/skills/openapi-to-generate/references/mcp-workflow.md",
 			mutate: (contents) =>
 				contents.replace('  "targets": ["<exact-target>"],\n', ""),
@@ -1549,6 +1556,15 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 					"degraded-apply-token-old",
 				),
 			failure: /missing required case degraded-apply-token-expired/,
+		},
+		{
+			path: ".agents/skills/openapi-to-generate/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace(
+					"degraded-setup-any-other-state",
+					"degraded-setup-analysis-only",
+				),
+			failure: /missing required case degraded-setup-any-other-state/,
 		},
 	];
 	for (const contractCase of cases) {
@@ -1601,6 +1617,21 @@ test("consumer generation Skill preserves trigger, workflow, approval, and evalu
 		await auditAgentAndSkillContracts(missingDistributionFileRoot),
 		/consumer Skill file is not tracked by Git: .*controlled-write\.md/,
 	);
+
+	const openHandoffDocumentRoot = await createContractFixture(t);
+	await mutateTrackedFixture(
+		openHandoffDocumentRoot,
+		"docs/skills.md",
+		(contents) =>
+			contents.replace(
+				"No Generate handoff; finish or repair setup first.",
+				"Generate may start after manual judgment.",
+			),
+	);
+	assertFailure(
+		await auditAgentAndSkillContracts(openHandoffDocumentRoot),
+		/must allow only verified read-only and write-enabled states, then deny any other state/,
+	);
 });
 
 test("consumer setup Skill preserves routing, safety, files, and evaluation contracts", async (t) => {
@@ -1624,6 +1655,16 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			path: ".agents/skills/openapi-to-setup/SKILL.md",
 			mutate: (contents) => contents.replace("`PACKAGE_JSON_MISSING`", "`PACKAGE_MISSING`"),
 			failure: /missing required workflow marker `PACKAGE_JSON_MISSING`/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/SKILL.md",
+			mutate: (contents) =>
+				contents.replace(
+					"No Generate handoff; finish or repair setup first.",
+					"Generate handoff may be inferred.",
+				),
+			failure:
+				/must allow only verified read-only and write-enabled states, then deny any other state/,
 		},
 		{
 			path: ".agents/skills/openapi-to-setup/references/diagnosis.md",
@@ -1664,6 +1705,15 @@ test("consumer setup Skill preserves routing, safety, files, and evaluation cont
 			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
 			mutate: (contents) => contents.replace("degraded-windows-no-nofollow", "degraded-windows-portable-read"),
 			failure: /missing required case degraded-windows-no-nofollow/,
+		},
+		{
+			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",
+			mutate: (contents) =>
+				contents.replace(
+					"degraded-handoff-any-other-state",
+					"degraded-handoff-analysis-only",
+				),
+			failure: /missing required case degraded-handoff-any-other-state/,
 		},
 		{
 			path: ".agents/skills/openapi-to-setup/references/evaluation-matrix.yaml",


### PR DESCRIPTION
## Summary

- make setup inspection portable when `O_NOFOLLOW` is unavailable while preserving bounded same-handle reads, real-root containment, regular-file checks, opened-file identity checks, and pre/post-read metadata validation
- add Windows setup-inspector coverage to the A1 cross-platform workflow and document that these checks narrow races but are not an operating-system-level atomic snapshot
- define one fail-closed Setup-to-Generate handoff matrix: verified read-only schemas allow discovery/contract/Dry Run only; verified write-enabled schemas may begin the separately approved Prepare/Apply flow; every other state denies handoff
- strengthen MCP Consumer Skill schema contracts, distribution checks, evaluation inputs, documentation, and repository negative tests

## Security and ownership boundaries

- Setup owns package/config/ignore/Host writes through exact Setup Plan approval.
- Generate owns operation selection, generation Apply, and handwritten business integration through separate exact approval.
- `--allow-write` is neither Setup Plan approval nor generation Apply approval.
- The portable fallback is fail-closed but is not an OS-level atomic snapshot; Git state and `observedStateHash` are rechecked before Apply.

## Validation

- PASS `node --test scripts/openapi-to-setup.node-test.mjs`: 27/27
- PASS MCP typecheck
- PASS `pnpm test:mcp:unit`: 82/82
- PASS `pnpm test:mcp`: 136/136
- PASS `pnpm test:mcp:all`: 190 collected (189 passed, 1 platform skip), plus cross-platform smoke, benchmark regression, and stress scripts
- PASS repository contract tests: 83/83
- PASS release script tests: 174/174
- PASS `pnpm lint:ci` and changed-file lint
- PASS final commit-hook `verify:precommit`: 99 files passed, 1 platform file skipped; 658 tests passed, 2 platform tests skipped
- PASS base-to-final `git diff --check`

## Distribution smoke

The official Codex Skill installer installed both `.agents/skills/openapi-to-setup` and `.agents/skills/openapi-to-generate` from exact commit `4ec0c24b019d596ffb22e6e4b77ad0780383a19b`. All 14 installed files were present, required scripts parsed, relative links resolved, no machine paths or credential-like content were found, and installed bytes matched the committed directories.

## Combined-diff review

- Base: `68a0b3ea31a69e2eaf1a52f0d5c5b79479b94800`
- Final head: `4ec0c24b019d596ffb22e6e4b77ad0780383a19b`
- Scope: 21 files, 984 additions, 82 deletions
- First independent review found one P1: aggregate MCP expected counts were stale after a new contract test.
- Repair: updated maintained counts to unit=82, test=136, all=190 and reran both aggregate groups.
- Fresh post-repair independent review: READY, no P0/P1 findings and no concrete P2 findings.

## Changeset

No Changeset. This PR changes Consumer Skills, internal validation/tests, CI coverage, and documentation without changing a published npm runtime API or MCP Tool schema.