### PR TITLE
Consolidate packed consumer acceptance coverage

### DIFF
--- a/docs/codex-mcp.md
+++ b/docs/codex-mcp.md
@@ -124,3 +124,12 @@ list, current Tool inputSchema, and returned capability fields.
 The phase labels are historical: Phase 2.1 hardened Setup state binding and
 Phase 2.2 added Windows portable verified reads. They are not new Skills, and
 the operational order remains Setup first, then Generate.
+
+For maintainers, `pnpm release:smoke` is the canonical full packed consumer
+acceptance entry. Its narrow Setup-to-MCP bridge writes these supported
+project-relative Host forms in a repository-external temporary consumer,
+compares the repository-Skill Inspector's inferred mode with the named Tools
+from the locally packed MCP, checks current Tool Schemas, and invalidates the
+handoff after `observedStateHash` drift. It neither reads a user's
+`~/.codex` nor claims the Inspector is part of the npm tarball. See the
+[consumer acceptance coverage matrix](./testing/consumer-acceptance-matrix.md).

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -53,6 +53,16 @@ snapshot, so Git status and `observedStateHash` are checked again before a Setup
 Plan executes. The focused Inspector suite runs in the repository's real
 Ubuntu, macOS, and Windows A1 CI matrix.
 
+Those focused tests are the canonical setup state and safe-inspection
+coverage. The packed release smoke adds one narrow continuity check in the
+same repository-external consumer: the Inspector from the exact repository
+checkout must infer read-only or write-enabled consistently with the named
+Tools exposed by the MCP installed from that checkout's local tarballs. The
+bridge also proves a bound-file drift changes `observedStateHash`; it does not
+claim that the Inspector ships in the tarball or repeat MCP transaction tests.
+See the
+[consumer acceptance coverage matrix](./testing/consumer-acceptance-matrix.md).
+
 ## Approval-bound writes
 
 Every package install, initializer run, ignore change, and Codex config change

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -147,3 +147,20 @@ Hosts can be diagnosed, but their writes remain manual. Neither Skill uses a
 global package fallback, silently upgrades openapi-to, executes an untrusted
 generation config during setup diagnosis, or treats Tool count as capability
 proof.
+
+## Acceptance-test ownership
+
+The focused Setup Inspector Node tests own setup state transitions and safe
+inspection. `pnpm test:consumer:codegen` owns packed formal-plugin generation,
+strict compile, runtime, drift, and idempotence. Its
+`test:consumer:codegen:review` alias only exports a human-review snapshot after
+that same test passes. `pnpm release:smoke` is the canonical full packed
+consumer acceptance entry and reuses the codegen scenario plus its single
+tarball set.
+
+Release smoke also runs a narrow bridge between the repository-Skill Inspector
+and the packed MCP in one external consumer. It proves the inferred
+read-only/write-enabled mode agrees with the actual named Prepare/Apply
+capability and that Setup evidence expires on observed-state drift. It is not
+a model-behavior test or a second golden path. The complete assignment is in
+the [consumer acceptance coverage matrix](./testing/consumer-acceptance-matrix.md).

--- a/docs/testing/consumer-acceptance-matrix.md
+++ b/docs/testing/consumer-acceptance-matrix.md
@@ -1,0 +1,85 @@
+# Consumer acceptance coverage matrix
+
+This matrix assigns one canonical owner to each consumer-facing acceptance
+capability. Secondary coverage is corroborating evidence, not a second source
+of truth. The commands intentionally share the existing pack/install harness:
+no separate consumer golden path exists.
+
+Owner names used below:
+
+- `openapi-to-setup.node-test` means
+  `node --test scripts/openapi-to-setup.node-test.mjs`.
+- `test:consumer:codegen` means `pnpm test:consumer:codegen`.
+- `consumer-codegen review export` means
+  `pnpm test:consumer:codegen:review`; it is an artifact export after the same
+  specialist test passes, not another test layer.
+- `release:smoke` means `pnpm release:smoke`, the canonical full packed
+  consumer acceptance entry.
+- `MCP tests` means the unit, integration, stdio, write, recovery, and E2E
+  groups classified by `packages/mcp/scripts/run-test-group.mjs`.
+- `repository contract` means `pnpm verify:repository-contract`.
+- `A1 cross-platform` means `.github/workflows/a1-cross-platform.yml`.
+
+| Capability | Canonical owner | Secondary coverage | Packed artifact? | External consumer? | Cross-platform? | Notes / intentional gap |
+| --- | --- | --- | --- | --- | --- | --- |
+| Setup package detection | `openapi-to-setup.node-test` | repository contract | No | Temporary project | Yes: A1 | Distinguishes aggregate, MCP-only, missing, and version-conflict states. |
+| Setup package-manager detection | `openapi-to-setup.node-test` | A1 cross-platform | No | Temporary project | Yes: A1 | Covers declared manager, unique lockfile evidence, unknown managers, and conflicting/multiple lockfiles. |
+| Setup config detection | `openapi-to-setup.node-test` | repository contract | No | Temporary project | Yes: A1 | Reads supported config bytes without executing the config; multiple candidates block. |
+| Setup Codex Host detection | `openapi-to-setup.node-test` | `release:smoke` bridge | No | Temporary project | Yes: A1 | Conservative text inspection owns state inference; the bridge verifies packed runtime agreement only. |
+| Setup observedStateHash | `openapi-to-setup.node-test` | `release:smoke` bridge | No | Temporary project | Yes: A1 | Binds manifest, lockfile, generation config, ignore file, Codex config, and relevant states. |
+| Setup portable verified reads | `openapi-to-setup.node-test` | A1 cross-platform | No | Temporary project | Yes: A1 | `O_NOFOLLOW` where available; verified `O_RDONLY` fallback elsewhere. |
+| Setup symlink/root boundary | `openapi-to-setup.node-test` | A1 cross-platform | No | Temporary project | Yes: A1 | Symlink capability may be skipped only when Windows denies symlink creation. |
+| Public package pack | `release:smoke` | `test:consumer:codegen` | Yes | Yes | Linux CI | Both call the same `packReleasePackages`; release smoke owns the complete packed acceptance claim. |
+| Packed dependency override | `release:smoke` | `test:consumer:codegen` | Yes | Yes | Linux CI | Both reuse `createPackedOverrides`; there is no second override implementation. |
+| Aggregate-only install | `release:smoke` | publication-manifest smoke | Yes | Yes | Linux CI | Installs only `openapi-to` while forcing all transitive workspace packages to the same tarball set. |
+| Installed CLI bins | `release:smoke` | `test:consumer:codegen`, A1 binary checks | Yes | Yes | Linux packed; A1 source builds on all OSes | Verifies installed `openapi` and `openapi-to`; A1 is portability evidence, not packed acceptance. |
+| Installed MCP bin | `release:smoke` | MCP stdio E2E, A1 binary checks | Yes | Yes | Linux packed; MCP/A1 smoke on all OSes | Covers aggregate wrapper and independently installed MCP package path. |
+| ESM/CJS exports | `release:smoke` | package unit tests | Yes | Yes | Linux CI | Tests aggregate and direct package exports from installed tarballs. |
+| TypeScript package surface | `release:smoke` | package typechecks | Yes | Yes | Linux CI | Strictly compiles public imports from the installed package set. |
+| Formal-plugin generation | `test:consumer:codegen` | `release:smoke` | Yes | Yes | Local/CI host | Release smoke reuses `runConsumerCodegenScenario`; it does not own a duplicate fixture suite. |
+| Generated TypeScript compile | `test:consumer:codegen` | `release:smoke` | Yes | Yes | Local/CI host | Strict compile with `skipLibCheck: false` owns generated-consumer validity. |
+| Generated Zod runtime | `test:consumer:codegen` | plugin tests, `release:smoke` | Yes | Yes | Local/CI host | Executes generated schemas with Zod 4. |
+| Idempotent regeneration | `test:consumer:codegen` | plugin fixtures | Yes | Yes | Local/CI host | Compares the complete generated file set and bytes. |
+| Drift detection and recovery | `test:consumer:codegen` | Core/CLI generation tests | Yes | Yes | Local/CI host | Injects managed-file drift, requires exit 6, regenerates, recompiles, and checks original bytes. |
+| Review snapshot export | `consumer-codegen review export` | `consumer-codegen-smoke.node-test` | Derived from packed run | Yes | Local maintainer workflow | Human-review artifact only; intentionally not a separately authoritative E2E. |
+| MCP stdio startup | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Yes: MCP cross-platform smoke | MCP lifecycle and protocol stdout integrity remain owned by MCP tests. |
+| Tool name matrix | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Yes: MCP cross-platform smoke | Names and mode semantics matter; a count by itself is not capability evidence. |
+| Tool input/output Schema | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Schema unit tests own production contracts; packed smoke verifies installed metadata. |
+| Tool annotations | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Packed smoke checks read-only, destructive, and idempotent hints. |
+| Target listing | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Release smoke verifies target order from installed tarballs. |
+| Operation search | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Target-scoped same-operation-name isolation is covered. |
+| Operation contract retrieval | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Bounded target-scoped contract retrieval is verified. |
+| Dry Run | `MCP tests` | `release:smoke`, `test:consumer:codegen` CLI dry-run | Yes in secondary | Yes in secondary | Linux packed | MCP tests own Tool semantics; specialist codegen separately owns CLI no-write behavior. |
+| Prepare | `release:smoke` | MCP integration/E2E | Yes | Yes | Linux packed | Canonical packed-consumer proof; MCP tests retain deeper protocol and failure-path coverage. Prepare remains write-free and separately approval-bound. |
+| Apply | `release:smoke` | MCP integration/E2E | Yes | Yes | Linux packed | Canonical packed-consumer proof; MCP tests retain deeper protocol and failure-path coverage. `--allow-write` exposes capability but is not Apply approval. |
+| Token replay rejection | `MCP tests` | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | The bridge does not repeat token protocol coverage. |
+| planHash drift rejection | `MCP tests` | `release:smoke` current-plan binding | Yes in secondary | Yes in secondary | Linux packed | Source/config/ownership/selection drift belongs to controlled-write tests; the bridge checks only Setup evidence drift. |
+| Three-state commit | MCP write/recovery tests | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Generated output, ownership, and selection state commit or roll back together. |
+| Output ownership | MCP write/recovery tests | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Preserves unmanaged files and rejects stale/unsafe ownership. |
+| Remote document policy | MCP integration/E2E | `release:smoke` | Yes in secondary | Yes in secondary | Linux packed | Covers operator ceilings, private hosts, redirect headers, and redaction. |
+| Setup Inspector ↔ packed MCP read-only agreement | `release:smoke` bridge | `openapi-to-setup.node-test`, MCP tests | Yes | Yes | Release-smoke platform | Repository-Skill Inspector must infer read-only while the equivalent packed MCP command omits Prepare and Apply. |
+| Setup Inspector ↔ packed MCP write-enabled agreement | `release:smoke` bridge | `openapi-to-setup.node-test`, MCP tests | Yes | Yes | Release-smoke platform | Repository-Skill Inspector must infer write-enabled while the equivalent packed MCP command exposes Prepare and Apply with current Schemas. |
+| Consumer acceptance entrypoint and no-duplication contract | `repository contract` | bridge Node tests | No | No | Platform-neutral Node | Guards the matrix, three canonical commands, one release-smoke pack call, bridge wiring/check IDs, and forbidden duplicate golden-path patterns. |
+
+## Boundaries and intentional gaps
+
+`release:smoke` creates the tarballs once, reuses them for the formal-plugin
+scenario and all packed package/MCP checks, and runs the Setup-to-MCP bridge in
+the already installed external consumer. The bridge uses the Setup Inspector
+from the exact repository checkout and the MCP runtime installed from that
+checkout's tarballs. The Inspector is not claimed to ship in an npm package.
+
+The bridge proves only:
+
+```text
+Inspector inferred mode ↔ packed MCP actual named Tool capability
+```
+
+It does not repeat formal-plugin edge cases, CLI coverage, remote policy,
+Prepare/Apply transaction contents, replay, or recovery. Those remain with
+their canonical owners above.
+
+Real Agent natural-language behavior, Host trust prompts, Host restart/UI
+interaction, and human review of generated code are intentionally not modeled
+as deterministic automated tests. Static Skill contracts and Tool counts do
+not substitute for those behaviors.

--- a/docs/testing/consumer-codegen.md
+++ b/docs/testing/consumer-codegen.md
@@ -1,5 +1,12 @@
 # Packed formal-plugin consumer code generation
 
+`pnpm test:consumer:codegen` is the packed formal-plugin consumer codegen
+specialist test. It owns generated file, strict compile, runtime, drift, and
+idempotence coverage; it is not the full packed consumer release acceptance
+entry. See the
+[consumer acceptance coverage matrix](./consumer-acceptance-matrix.md) for the
+canonical owner of each adjacent capability.
+
 Run the independent external-consumer smoke after building the repository:
 
 ```shell
@@ -77,21 +84,27 @@ exercise repository workspaces rather than a newly installed tarball.
 `release:smoke` reuses this exact scenario with its already packed tarballs,
 alongside the package-surface, binary, and MCP checks.
 
-There are two primary maintainer entry points:
+There is one specialist test with an optional review-export mode:
 
 ```shell
 pnpm test:consumer:codegen
 pnpm test:consumer:codegen:review
 ```
 
-`test:consumer:codegen` is the automation-oriented validation and always cleans
-its operating-system temporary workspace. For day-to-day human review of
-generated code, use `test:consumer:codegen:review`. It still installs and
-validates in the operating-system temporary directory, then, only after
+`test:consumer:codegen` is the automation-oriented specialist validation and
+always cleans its operating-system temporary workspace. For day-to-day human
+review of generated code, use `test:consumer:codegen:review`. The latter is not
+a different consumer E2E or a second test layer: it invokes the same specialist
+test and, only after
 validation, drift recovery, strict compilation, the final current check, and
 byte-stable regeneration have passed, atomically exports a compact snapshot to
 `.ci-artifacts/consumer-codegen-review/current`. The original temporary root is
 then removed automatically.
+
+`pnpm release:smoke` remains the canonical full packed consumer acceptance
+entry. It packs once, reuses the same tarballs for this exact codegen scenario,
+then verifies package surfaces, bins, MCP stdio/capabilities, controlled
+Prepare/Apply, and the narrow Setup Inspector-to-packed-MCP handoff bridge.
 
 The review snapshot contains `report.json`, the OpenAPI fixture and config,
 request stub, consumer usage, TypeScript config, `pnpm-lock.yaml`, all final

--- a/scripts/release/pack-install-smoke.mjs
+++ b/scripts/release/pack-install-smoke.mjs
@@ -19,6 +19,7 @@ import {
 	packReleasePackages,
 } from "./pack-smoke-helpers.mjs";
 import { verifyPublicationArtifacts } from "./publication.mjs";
+import { runSetupMcpHandoffScenario } from "./setup-mcp-handoff-smoke.mjs";
 
 const repositoryRoot = resolve(
 	dirname(fileURLToPath(import.meta.url)),
@@ -223,6 +224,7 @@ await Promise.all([
 let succeeded = false;
 let remoteFixtureServer;
 let packageBaseline;
+let setupMcpHandoff;
 try {
 	const packed = options.publicationManifest
 		? (
@@ -510,6 +512,11 @@ paths:
 };
 `,
 	);
+	setupMcpHandoff = await runSetupMcpHandoffScenario({
+		consumerRoot: installationDirectory,
+		packed,
+		repositoryRoot,
+	});
 	await writeFile(
 		join(installationDirectory, "esm-smoke.mjs"),
 		`import * as openapiTo from "openapi-to";
@@ -1011,6 +1018,7 @@ await writeClient.close();
 						?.size,
 					...packageBaseline,
 				},
+				setupMcpHandoff,
 				checks: [
 					"esm",
 					"cjs",
@@ -1038,6 +1046,9 @@ await writeClient.close();
 					"mcp-token-replay",
 					"mcp-current",
 					"mcp-full-prepare-unchanged",
+					"setup-packed-mcp-read-only-handoff",
+					"setup-packed-mcp-write-handoff",
+					"setup-handoff-state-drift",
 					"validate-json",
 					"validate-error-exit",
 					"inspect-json",

--- a/scripts/release/setup-mcp-handoff-smoke.mjs
+++ b/scripts/release/setup-mcp-handoff-smoke.mjs
@@ -1,0 +1,360 @@
+import { execFile } from "node:child_process";
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const prepareToolName = "openapi_prepare_generation";
+const applyToolName = "openapi_apply_generation";
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+function tomlString(value) {
+	return JSON.stringify(value);
+}
+
+export function createCodexHostLaunch({
+	mode,
+	platform = process.platform,
+} = {}) {
+	assert(
+		mode === "read-only" || mode === "write-enabled",
+		"Setup MCP handoff mode must be read-only or write-enabled.",
+	);
+	const mcpArguments = [
+		"exec",
+		"openapi-to-mcp",
+		"--workspace-root",
+		".",
+		"--config",
+		"openapi.config.cjs",
+	];
+	if (mode === "write-enabled") mcpArguments.push("--allow-write");
+
+	const command = platform === "win32" ? "cmd.exe" : "pnpm";
+	const args =
+		platform === "win32"
+			? ["/d", "/s", "/c", `pnpm ${mcpArguments.join(" ")}`]
+			: mcpArguments;
+	const configLines = [
+		"[mcp_servers.openapi_to]",
+		`command = ${tomlString(command)}`,
+		"args = [",
+		...args.map((argument) => `  ${tomlString(argument)},`),
+		"]",
+		'cwd = "."',
+	];
+	if (mode === "write-enabled") {
+		configLines.push(
+			"",
+			"[mcp_servers.openapi_to.tools.openapi_apply_generation]",
+			'approval_mode = "prompt"',
+		);
+	}
+	return {
+		command,
+		args,
+		configToml: `${configLines.join("\n")}\n`,
+	};
+}
+
+function assertObjectSchema(schema, toolName, direction) {
+	assert(
+		schema &&
+			typeof schema === "object" &&
+			!Array.isArray(schema) &&
+			schema.type === "object",
+		`${toolName} ${direction}Schema must be an object Schema.`,
+	);
+}
+
+function assertSchemaProperties(tool, requiredProperties) {
+	const properties = tool.inputSchema?.properties;
+	assert(
+		properties && typeof properties === "object" && !Array.isArray(properties),
+		`${tool.name} inputSchema must expose properties.`,
+	);
+	for (const property of requiredProperties) {
+		assert(
+			Object.hasOwn(properties, property),
+			`${tool.name} inputSchema is missing ${property}.`,
+		);
+	}
+}
+
+export function assertModeCapabilityAgreement({ inferredMode, tools }) {
+	assert(Array.isArray(tools), "Packed MCP Tool list must be an array.");
+	const byName = new Map();
+	for (const tool of tools) {
+		assert(
+			tool && typeof tool.name === "string" && !byName.has(tool.name),
+			"Packed MCP Tool names must be unique strings.",
+		);
+		assertObjectSchema(tool.inputSchema, tool.name, "input");
+		assertObjectSchema(tool.outputSchema, tool.name, "output");
+		byName.set(tool.name, tool);
+	}
+	for (const required of [
+		"openapi_validate",
+		"openapi_list_targets",
+		"openapi_generate_dry_run",
+	]) {
+		assert(
+			byName.has(required),
+			`Packed MCP is missing required Tool ${required}.`,
+		);
+	}
+	assertSchemaProperties(byName.get("openapi_generate_dry_run"), [
+		"targets",
+		"scope",
+	]);
+
+	const capabilities = {
+		prepare: byName.has(prepareToolName),
+		apply: byName.has(applyToolName),
+	};
+	if (inferredMode === "read-only") {
+		assert(
+			!capabilities.prepare && !capabilities.apply,
+			"Read-only Setup mode must not expose Prepare or Apply.",
+		);
+		return capabilities;
+	}
+	assert(
+		inferredMode === "write-enabled",
+		`Unsupported Setup Inspector mode ${String(inferredMode)}.`,
+	);
+	assert(
+		capabilities.prepare && capabilities.apply,
+		"Write-enabled Setup mode must expose both Prepare and Apply.",
+	);
+	assertSchemaProperties(byName.get(prepareToolName), ["targets", "selection"]);
+	const applyTool = byName.get(applyToolName);
+	assertSchemaProperties(applyTool, ["planId", "token", "approvedPlanHash"]);
+	const applyRequired = new Set(applyTool.inputSchema.required);
+	for (const property of ["planId", "token", "approvedPlanHash"]) {
+		assert(
+			applyRequired.has(property),
+			`${applyToolName} inputSchema must require ${property}.`,
+		);
+	}
+	return capabilities;
+}
+
+export function assertObservedStateHashChanged(previous, current) {
+	for (const value of [previous, current]) {
+		assert(
+			typeof value === "string" && /^[a-f0-9]{64}$/.test(value),
+			"Setup Inspector must return a SHA-256 observedStateHash.",
+		);
+	}
+	assert(
+		previous !== current,
+		"Setup handoff evidence must become stale when a bound file drifts.",
+	);
+	return true;
+}
+
+export function createSetupMcpHandoffReport({
+	withoutHostState,
+	readOnlyState,
+	writeEnabledState,
+	readOnlyMode,
+	writeEnabledMode,
+	readOnlyCapabilities,
+	writeEnabledCapabilities,
+	observedStateHashChanged,
+}) {
+	return {
+		success: true,
+		inspectorSource: "repository-skill",
+		runtimeSource: "packed-tarballs",
+		states: {
+			withoutHost: withoutHostState,
+			readOnly: readOnlyState,
+			writeEnabled: writeEnabledState,
+		},
+		modes: {
+			readOnly: readOnlyMode,
+			writeEnabled: writeEnabledMode,
+		},
+		capabilities: {
+			readOnlyPrepare: readOnlyCapabilities.prepare,
+			readOnlyApply: readOnlyCapabilities.apply,
+			writePrepare: writeEnabledCapabilities.prepare,
+			writeApply: writeEnabledCapabilities.apply,
+		},
+		observedStateHashChanged,
+	};
+}
+
+async function inspectProject(repositoryRoot, consumerRoot) {
+	const inspector = join(
+		repositoryRoot,
+		".agents/skills/openapi-to-setup/scripts/inspect-project.mjs",
+	);
+	let result;
+	try {
+		result = await execFileAsync(
+			process.execPath,
+			[inspector, "--root", consumerRoot],
+			{ maxBuffer: 128 * 1024 },
+		);
+	} catch {
+		throw new Error(
+			"Repository Setup Inspector failed during packed MCP handoff.",
+		);
+	}
+	assert(
+		result.stderr === "",
+		"Repository Setup Inspector wrote unexpected stderr during packed MCP handoff.",
+	);
+	try {
+		return JSON.parse(result.stdout);
+	} catch {
+		throw new Error("Repository Setup Inspector returned invalid JSON.");
+	}
+}
+
+async function listPackedMcpTools(consumerRoot, launch) {
+	const requireFromConsumer = createRequire(join(consumerRoot, "package.json"));
+	const [{ Client }, { StdioClientTransport }] = await Promise.all([
+		import(
+			pathToFileURL(
+				requireFromConsumer.resolve(
+					"@modelcontextprotocol/sdk/client/index.js",
+				),
+			).href
+		),
+		import(
+			pathToFileURL(
+				requireFromConsumer.resolve(
+					"@modelcontextprotocol/sdk/client/stdio.js",
+				),
+			).href
+		),
+	]);
+	const stderr = [];
+	const transport = new StdioClientTransport({
+		command: launch.command,
+		args: launch.args,
+		cwd: consumerRoot,
+		stderr: "pipe",
+	});
+	transport.stderr?.on("data", (chunk) => {
+		if (stderr.join("").length < 64 * 1024) stderr.push(String(chunk));
+	});
+	const client = new Client({
+		name: "setup-packed-mcp-handoff-smoke",
+		version: "1.0.0",
+	});
+	try {
+		await client.connect(transport);
+		const listed = await client.listTools();
+		assert(
+			!stderr.join("").includes("Unable to start server"),
+			"Packed MCP reported a startup failure during Setup handoff.",
+		);
+		return listed.tools;
+	} catch {
+		throw new Error("Packed MCP Setup handoff connection failed.");
+	} finally {
+		await client.close().catch(() => undefined);
+	}
+}
+
+async function assertPackedInstallation(consumerRoot, packed) {
+	for (const packageName of ["openapi-to", "@openapi-to/mcp"]) {
+		const expected = packed.find(({ name }) => name === packageName);
+		assert(expected, `Packed release inputs are missing ${packageName}.`);
+		const installed = JSON.parse(
+			await readFile(
+				join(
+					consumerRoot,
+					"node_modules",
+					...packageName.split("/"),
+					"package.json",
+				),
+				"utf8",
+			),
+		);
+		assert(
+			installed.version === expected.version,
+			`Installed ${packageName} does not match the packed release input.`,
+		);
+	}
+}
+
+export async function runSetupMcpHandoffScenario({
+	consumerRoot,
+	packed,
+	repositoryRoot,
+}) {
+	await assertPackedInstallation(consumerRoot, packed);
+	const withoutHost = await inspectProject(repositoryRoot, consumerRoot);
+	assert(
+		withoutHost.state === "HOST_CONFIG_MISSING" &&
+			withoutHost.codex?.inferredMode === "missing",
+		"Setup Inspector must report HOST_CONFIG_MISSING before Host configuration.",
+	);
+
+	const codexDirectory = join(consumerRoot, ".codex");
+	const codexConfig = join(codexDirectory, "config.toml");
+	await mkdir(codexDirectory);
+
+	const readOnlyLaunch = createCodexHostLaunch({ mode: "read-only" });
+	await writeFile(codexConfig, readOnlyLaunch.configToml);
+	const readOnly = await inspectProject(repositoryRoot, consumerRoot);
+	assert(
+		readOnly.state === "HOST_CONFIG_READY" &&
+			readOnly.codex?.inferredMode === "read-only",
+		"Setup Inspector must infer the read-only Host configuration.",
+	);
+	assertObservedStateHashChanged(
+		withoutHost.observedStateHash,
+		readOnly.observedStateHash,
+	);
+	const readOnlyCapabilities = assertModeCapabilityAgreement({
+		inferredMode: readOnly.codex.inferredMode,
+		tools: await listPackedMcpTools(consumerRoot, readOnlyLaunch),
+	});
+
+	const writeEnabledLaunch = createCodexHostLaunch({ mode: "write-enabled" });
+	await writeFile(codexConfig, writeEnabledLaunch.configToml);
+	const writeEnabled = await inspectProject(repositoryRoot, consumerRoot);
+	assert(
+		writeEnabled.state === "HOST_CONFIG_READY" &&
+			writeEnabled.codex?.inferredMode === "write-enabled",
+		"Setup Inspector must infer the write-enabled Host configuration.",
+	);
+	assertObservedStateHashChanged(
+		readOnly.observedStateHash,
+		writeEnabled.observedStateHash,
+	);
+	const writeEnabledCapabilities = assertModeCapabilityAgreement({
+		inferredMode: writeEnabled.codex.inferredMode,
+		tools: await listPackedMcpTools(consumerRoot, writeEnabledLaunch),
+	});
+
+	await appendFile(codexConfig, "# setup handoff drift probe\n");
+	const drifted = await inspectProject(repositoryRoot, consumerRoot);
+	const observedStateHashChanged = assertObservedStateHashChanged(
+		writeEnabled.observedStateHash,
+		drifted.observedStateHash,
+	);
+
+	return createSetupMcpHandoffReport({
+		withoutHostState: withoutHost.state,
+		readOnlyState: readOnly.state,
+		writeEnabledState: writeEnabled.state,
+		readOnlyMode: readOnly.codex.inferredMode,
+		writeEnabledMode: writeEnabled.codex.inferredMode,
+		readOnlyCapabilities,
+		writeEnabledCapabilities,
+		observedStateHashChanged,
+	});
+}

--- a/scripts/release/setup-mcp-handoff-smoke.node-test.mjs
+++ b/scripts/release/setup-mcp-handoff-smoke.node-test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+	assertModeCapabilityAgreement,
+	assertObservedStateHashChanged,
+	createCodexHostLaunch,
+	createSetupMcpHandoffReport,
+} from "./setup-mcp-handoff-smoke.mjs";
+
+function tool(name, properties = {}, required = []) {
+	return {
+		name,
+		inputSchema: { type: "object", properties, required },
+		outputSchema: { type: "object", properties: {} },
+	};
+}
+
+function readOnlyTools() {
+	return [
+		tool("openapi_validate"),
+		tool("openapi_list_targets"),
+		tool("openapi_generate_dry_run", { targets: {}, scope: {} }),
+	];
+}
+
+function writeEnabledTools() {
+	return [
+		...readOnlyTools(),
+		tool("openapi_prepare_generation", { targets: {}, selection: {} }),
+		tool(
+			"openapi_apply_generation",
+			{ planId: {}, token: {}, approvedPlanHash: {} },
+			["planId", "token", "approvedPlanHash"],
+		),
+	];
+}
+
+test("constructs safe read-only and write-enabled Codex Host launches", () => {
+	const readOnly = createCodexHostLaunch({
+		mode: "read-only",
+		platform: "linux",
+	});
+	assert.equal(readOnly.command, "pnpm");
+	assert.deepEqual(readOnly.args, [
+		"exec",
+		"openapi-to-mcp",
+		"--workspace-root",
+		".",
+		"--config",
+		"openapi.config.cjs",
+	]);
+	assert.doesNotMatch(readOnly.configToml, /--allow-write|approval_mode/);
+
+	const writeEnabled = createCodexHostLaunch({
+		mode: "write-enabled",
+		platform: "linux",
+	});
+	assert.deepEqual(writeEnabled.args, [...readOnly.args, "--allow-write"]);
+	assert.match(writeEnabled.configToml, /--allow-write/);
+	assert.match(writeEnabled.configToml, /approval_mode = "prompt"/);
+
+	const windows = createCodexHostLaunch({
+		mode: "write-enabled",
+		platform: "win32",
+	});
+	assert.equal(windows.command, "cmd.exe");
+	assert.deepEqual(windows.args.slice(0, 3), ["/d", "/s", "/c"]);
+	assert.equal(
+		windows.args[3],
+		"pnpm exec openapi-to-mcp --workspace-root . --config openapi.config.cjs --allow-write",
+	);
+	assert.doesNotMatch(windows.configToml, /[A-Za-z]:[\\/]|\\\\/);
+});
+
+test("derives capabilities from Tool names and verifies their Schemas", () => {
+	assert.deepEqual(
+		assertModeCapabilityAgreement({
+			inferredMode: "read-only",
+			tools: readOnlyTools(),
+		}),
+		{ prepare: false, apply: false },
+	);
+	assert.deepEqual(
+		assertModeCapabilityAgreement({
+			inferredMode: "write-enabled",
+			tools: writeEnabledTools(),
+		}),
+		{ prepare: true, apply: true },
+	);
+});
+
+test("fails closed when read-only exposes Prepare or Apply", () => {
+	for (const writeTool of writeEnabledTools().slice(-2)) {
+		assert.throws(
+			() =>
+				assertModeCapabilityAgreement({
+					inferredMode: "read-only",
+					tools: [...readOnlyTools(), writeTool],
+				}),
+			/Read-only Setup mode must not expose Prepare or Apply/,
+		);
+	}
+});
+
+test("fails closed when write-enabled omits Prepare or Apply", () => {
+	const complete = writeEnabledTools();
+	for (const missingName of [
+		"openapi_prepare_generation",
+		"openapi_apply_generation",
+	]) {
+		assert.throws(
+			() =>
+				assertModeCapabilityAgreement({
+					inferredMode: "write-enabled",
+					tools: complete.filter(({ name }) => name !== missingName),
+				}),
+			/Write-enabled Setup mode must expose both Prepare and Apply/,
+		);
+	}
+});
+
+test("rejects Inspector modes that cannot authorize the observed capability", () => {
+	assert.throws(
+		() =>
+			assertModeCapabilityAgreement({
+				inferredMode: "analysis-only",
+				tools: readOnlyTools(),
+			}),
+		/Unsupported Setup Inspector mode analysis-only/,
+	);
+	assert.throws(
+		() =>
+			assertModeCapabilityAgreement({
+				inferredMode: "read-only",
+				tools: writeEnabledTools(),
+			}),
+		/Read-only Setup mode must not expose Prepare or Apply/,
+	);
+});
+
+test("requires observedStateHash drift before expiring handoff evidence", () => {
+	const first = "a".repeat(64);
+	const second = "b".repeat(64);
+	assert.equal(assertObservedStateHashChanged(first, second), true);
+	assert.throws(
+		() => assertObservedStateHashChanged(first, first),
+		/Setup handoff evidence must become stale/,
+	);
+	assert.throws(
+		() => assertObservedStateHashChanged("not-a-hash", second),
+		/Setup Inspector must return a SHA-256/,
+	);
+});
+
+test("returns a stable bounded bridge report without paths or configuration", () => {
+	const report = createSetupMcpHandoffReport({
+		withoutHostState: "HOST_CONFIG_MISSING",
+		readOnlyState: "HOST_CONFIG_READY",
+		writeEnabledState: "HOST_CONFIG_READY",
+		readOnlyMode: "read-only",
+		writeEnabledMode: "write-enabled",
+		readOnlyCapabilities: { prepare: false, apply: false },
+		writeEnabledCapabilities: { prepare: true, apply: true },
+		observedStateHashChanged: true,
+	});
+	assert.deepEqual(report, {
+		success: true,
+		inspectorSource: "repository-skill",
+		runtimeSource: "packed-tarballs",
+		states: {
+			withoutHost: "HOST_CONFIG_MISSING",
+			readOnly: "HOST_CONFIG_READY",
+			writeEnabled: "HOST_CONFIG_READY",
+		},
+		modes: {
+			readOnly: "read-only",
+			writeEnabled: "write-enabled",
+		},
+		capabilities: {
+			readOnlyPrepare: false,
+			readOnlyApply: false,
+			writePrepare: true,
+			writeApply: true,
+		},
+		observedStateHashChanged: true,
+	});
+	assert.doesNotMatch(JSON.stringify(report), /config\.toml|[/\\]tmp|token/);
+});

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -48,6 +48,7 @@ const DOCUMENT_ENTRYPOINTS = [
 	"docs/ai-hosts/claude-code.md",
 	"docs/ai-hosts/cursor.md",
 	"docs/ai-hosts/generic-stdio.md",
+	"docs/testing/consumer-acceptance-matrix.md",
 	"docs/testing/consumer-codegen.md",
 	"docs/testing/ci-diagnostics.md",
 ];
@@ -4162,6 +4163,138 @@ export async function auditCiDiagnosticsContracts(root = repositoryRoot) {
 	return sortedUnique(failures);
 }
 
+export async function auditConsumerAcceptanceContracts(root = repositoryRoot) {
+	const failures = [];
+	const matrixPath = join(
+		root,
+		"docs/testing/consumer-acceptance-matrix.md",
+	);
+	const releaseSmokePath = join(
+		root,
+		"scripts/release/pack-install-smoke.mjs",
+	);
+	const bridgePath = join(
+		root,
+		"scripts/release/setup-mcp-handoff-smoke.mjs",
+	);
+	const rootManifest = await readJson(join(root, "package.json"));
+
+	for (const [name, expected] of [
+		[
+			"test:consumer:codegen",
+			"node scripts/consumer-codegen-smoke.mjs",
+		],
+		[
+			"test:consumer:codegen:review",
+			"pnpm test:consumer:codegen -- --export-review-dir .ci-artifacts/consumer-codegen-review/current",
+		],
+		["release:smoke", "node scripts/release/pack-install-smoke.mjs"],
+	]) {
+		if (rootManifest.scripts?.[name] !== expected) {
+			failures.push(
+				`${name} must retain its canonical consumer acceptance responsibility`,
+			);
+		}
+	}
+	if (rootManifest.scripts?.["test:consumer:golden"]) {
+		failures.push("test:consumer:golden must not duplicate release:smoke");
+	}
+
+	if (!(await exists(matrixPath))) {
+		failures.push("missing consumer acceptance coverage matrix");
+	} else {
+		const matrix = await readFile(matrixPath, "utf8");
+		for (const owner of [
+			"`openapi-to-setup.node-test`",
+			"`test:consumer:codegen`",
+			"`release:smoke`",
+		]) {
+			if (!matrix.includes(owner)) {
+				failures.push(
+					`consumer acceptance matrix is missing canonical owner ${owner}`,
+				);
+			}
+		}
+		for (const capability of [
+			"Setup Inspector ↔ packed MCP read-only agreement",
+			"Setup Inspector ↔ packed MCP write-enabled agreement",
+			"Token replay rejection",
+			"Three-state commit",
+			"Remote document policy",
+		]) {
+			if (!matrix.includes(`| ${capability} |`)) {
+				failures.push(
+					`consumer acceptance matrix is missing capability ${capability}`,
+				);
+			}
+		}
+	}
+
+	if (!(await exists(bridgePath))) {
+		failures.push("missing Setup to packed MCP handoff bridge");
+	} else {
+		const bridge = await readFile(bridgePath, "utf8");
+		for (const [pattern, label] of [
+			[/packReleasePackages/, "packReleasePackages"],
+			[/\bpnpm\s+link\b/, "pnpm link"],
+			[/~\/\.codex|homedir\s*\(|process\.env\.(?:HOME|USERPROFILE)/, "user Codex home"],
+			[/registry\.npmjs|npmjs\.org|\bpnpm\s+add\b|\bnpm\s+install\b/, "npm registry installation"],
+		]) {
+			if (pattern.test(bridge)) {
+				failures.push(`Setup to packed MCP bridge must not use ${label}`);
+			}
+		}
+	}
+
+	if (!(await exists(releaseSmokePath))) {
+		failures.push("missing packed release smoke");
+	} else {
+		const releaseSmoke = await readFile(releaseSmokePath, "utf8");
+		const bridgeCall = releaseSmoke.lastIndexOf("runSetupMcpHandoffScenario");
+		if (bridgeCall < 0) {
+			failures.push("release smoke must call the Setup to packed MCP bridge");
+		} else {
+			const callSource = releaseSmoke.slice(bridgeCall, bridgeCall + 400);
+			for (const argument of [
+				"consumerRoot: installationDirectory",
+				"packed",
+				"repositoryRoot",
+			]) {
+				if (!callSource.includes(argument)) {
+					failures.push(
+						`release smoke bridge call must reuse ${argument}`,
+					);
+				}
+			}
+		}
+		if (
+			(releaseSmoke.match(/await\s+packReleasePackages\s*\(/g) ?? [])
+				.length !== 1
+		) {
+			failures.push("release smoke must pack public packages exactly once");
+		}
+		for (const check of [
+			"setup-packed-mcp-read-only-handoff",
+			"setup-packed-mcp-write-handoff",
+			"setup-handoff-state-drift",
+		]) {
+			if (!releaseSmoke.includes(`"${check}"`)) {
+				failures.push(`release smoke checks are missing ${check}`);
+			}
+		}
+	}
+
+	for (const forbiddenPath of [
+		"scripts/consumer-golden-path.mjs",
+		"scripts/consumer-golden-path.node-test.mjs",
+	]) {
+		if (await exists(join(root, forbiddenPath))) {
+			failures.push(`duplicate consumer golden path exists: ${forbiddenPath}`);
+		}
+	}
+	return sortedUnique(failures);
+}
+
 export async function auditRepositoryContracts(root = repositoryRoot) {
 	const failures = [];
 	const rootManifest = await readJson(join(root, "package.json"));
@@ -4242,6 +4375,7 @@ export async function auditRepositoryContracts(root = repositoryRoot) {
 	failures.push(...(await auditCiDiagnosticsContracts(root)));
 	failures.push(...(await auditGitHubWorkflowContexts(root)));
 	failures.push(...(await auditPublicationContracts(root)));
+	failures.push(...(await auditConsumerAcceptanceContracts(root)));
 
 	if (
 		rootManifest.scripts?.["version:canary"] !==

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -16,6 +16,7 @@ import { promisify } from "node:util";
 import {
 	auditAgentAndSkillContracts,
 	auditCiDiagnosticsContracts,
+	auditConsumerAcceptanceContracts,
 	auditGitHubWorkflowContexts,
 	auditPublicationContracts,
 	auditRepositoryContracts,
@@ -37,6 +38,26 @@ async function writeFixtureFile(root, relativePath, contents) {
 	const path = join(root, relativePath);
 	await mkdir(dirname(path), { recursive: true });
 	await writeFile(path, contents);
+}
+
+async function createConsumerAcceptanceContractFixture(t) {
+	const root = await mkdtemp(
+		join(tmpdir(), "openapi-to-consumer-acceptance-contract-"),
+	);
+	t.after(() => rm(root, { recursive: true, force: true }));
+	for (const relativePath of [
+		"package.json",
+		"docs/testing/consumer-acceptance-matrix.md",
+		"scripts/release/pack-install-smoke.mjs",
+		"scripts/release/setup-mcp-handoff-smoke.mjs",
+	]) {
+		await writeFixtureFile(
+			root,
+			relativePath,
+			await readFile(join(repositoryRoot, relativePath), "utf8"),
+		);
+	}
+	return root;
 }
 
 async function git(root, ...args) {
@@ -439,6 +460,79 @@ test("repository scripts, workspaces, docs, packages, and binary claims stay ali
 		"openapi-to-generate",
 		"openapi-to-setup",
 	]);
+});
+
+test("consumer acceptance contract accepts the consolidated packed path", async (t) => {
+	const root = await createConsumerAcceptanceContractFixture(t);
+	assert.deepEqual(await auditConsumerAcceptanceContracts(root), []);
+});
+
+test("consumer acceptance contract rejects owner, bridge, and duplicate-path drift", async (t) => {
+	const missingOwnerRoot = await createConsumerAcceptanceContractFixture(t);
+	const matrixPath = join(
+		missingOwnerRoot,
+		"docs/testing/consumer-acceptance-matrix.md",
+	);
+	await writeFile(
+		matrixPath,
+		(await readFile(matrixPath, "utf8")).replaceAll(
+			"`release:smoke`",
+			"`removed-release-owner`",
+		),
+	);
+	assertFailure(
+		{ failures: await auditConsumerAcceptanceContracts(missingOwnerRoot) },
+		/missing canonical owner `release:smoke`/,
+	);
+
+	const missingCallRoot = await createConsumerAcceptanceContractFixture(t);
+	const releasePath = join(
+		missingCallRoot,
+		"scripts/release/pack-install-smoke.mjs",
+	);
+	await writeFile(
+		releasePath,
+		(await readFile(releasePath, "utf8")).replaceAll(
+			"runSetupMcpHandoffScenario",
+			"removedSetupMcpHandoffScenario",
+		),
+	);
+	assertFailure(
+		{ failures: await auditConsumerAcceptanceContracts(missingCallRoot) },
+		/release smoke must call the Setup to packed MCP bridge/,
+	);
+
+	for (const [source, failure] of [
+		["packReleasePackages();", /must not use packReleasePackages/],
+		["pnpm link openapi-to;", /must not use pnpm link/],
+		["homedir();", /must not use user Codex home/],
+		["npm install openapi-to;", /must not use npm registry installation/],
+	]) {
+		const forbiddenRoot = await createConsumerAcceptanceContractFixture(t);
+		const bridgePath = join(
+			forbiddenRoot,
+			"scripts/release/setup-mcp-handoff-smoke.mjs",
+		);
+		await writeFile(
+			bridgePath,
+			`${await readFile(bridgePath, "utf8")}\n${source}\n`,
+		);
+		assertFailure(
+			{ failures: await auditConsumerAcceptanceContracts(forbiddenRoot) },
+			failure,
+		);
+	}
+
+	const duplicateRoot = await createConsumerAcceptanceContractFixture(t);
+	await writeFixtureFile(
+		duplicateRoot,
+		"scripts/consumer-golden-path.mjs",
+		"export {};\n",
+	);
+	assertFailure(
+		{ failures: await auditConsumerAcceptanceContracts(duplicateRoot) },
+		/duplicate consumer golden path exists/,
+	);
 });
 
 test("blocking Actions workflows use controlled fixtures and retain diagnostic artifacts", async () => {


### PR DESCRIPTION
## Summary

- add a consumer acceptance coverage matrix with one canonical owner per capability
- bridge the repository Setup Inspector to the actual packed MCP in the existing external release-smoke consumer
- verify missing-host, read-only, write-enabled, and observed-state drift handoff states without adding another pack/install path
- document the distinct responsibilities of setup tests, consumer codegen, review export, and release smoke
- extend repository contracts and focused Node tests for the bridge boundaries

## Implementation boundaries

- reuses the existing `packReleasePackages`, packed overrides, external consumer, and official MCP SDK client
- keeps exactly one package-pack step in `release:smoke`
- does not add a consumer golden-path script, pack helper, fixture set, or npm runtime/schema change

## Validation

- `node --test scripts/openapi-to-setup.node-test.mjs`
- `node --test scripts/consumer-codegen-smoke.node-test.mjs`
- `node --test scripts/release/setup-mcp-handoff-smoke.node-test.mjs`
- `pnpm build`
- `pnpm test:consumer:codegen`
- `pnpm release:smoke`
- `pnpm test:release-scripts`
- `pnpm verify:repository-contract`
- `pnpm lint:ci`
- `pnpm lint:changed --base 3c9610407a297736bcc7048db85197825c675ea7`
- `pnpm verify:precommit` (99 test files passed, 1 skipped; 658 tests passed, 2 skipped)
- `git diff --check 3c9610407a297736bcc7048db85197825c675ea7`
- independent P0/P1 review: READY, P0=0, P1=0

## Release metadata

No Changeset: this change consolidates internal tests, CI coverage, repository contracts, and documentation without changing a public npm runtime API or MCP Tool Schema.