### PR TITLE
Ship versioned Skills with a hardened Codex installer

### DIFF
--- a/.changeset/curly-bottles-prove.md
+++ b/.changeset/curly-bottles-prove.md
@@ -1,0 +1,6 @@
+---
+"openapi-to": patch
+"@openapi-to/cli": patch
+---
+
+Ship the openapi-to Setup and Generate Skills with the npm distribution and add an explicit offline Codex Skill installer.

--- a/.github/workflows/a1-cross-platform.yml
+++ b/.github/workflows/a1-cross-platform.yml
@@ -43,6 +43,10 @@ jobs:
         run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id pnpm-launcher -- pnpm --version
       - name: Build packages
         run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id build -- pnpm build --concurrency=1
+      - name: Run focused Codex Skill installer tests
+        run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id codex-skills-installer-tests -- pnpm --filter @openapi-to/cli test:skills-installer
+      - name: Run built Codex Skill installer smoke
+        run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id codex-skills-installer-built-bin -- node scripts/codex-skills-installer-cross-platform-smoke.mjs
       - name: Run A1 focused contracts
         run: node scripts/ci-diagnostics/run-command.mjs --dir "${{ env.CI_DIAGNOSTIC_DIR }}" --id a1-contracts -- pnpm test:a1-contracts
       - name: Verify openapi CLI alias

--- a/README.md
+++ b/README.md
@@ -81,6 +81,36 @@ self-import.
 pnpm add -D openapi-to
 ```
 
+### Install the Codex consumer Skills
+
+The aggregate installation carries version-matched copies of
+`openapi-to-setup` and `openapi-to-generate` through its
+`@openapi-to/cli` dependency. Preview and then explicitly install those
+offline assets for Codex:
+
+```shell
+pnpm exec openapi skills install \
+  --host codex \
+  --dry-run
+
+pnpm exec openapi skills install \
+  --host codex
+```
+
+The installer performs no network access. It writes only
+`$CODEX_HOME/skills/openapi-to-setup` and
+`$CODEX_HOME/skills/openapi-to-generate`; when `CODEX_HOME` is unset, the
+root is `~/.codex/skills`. It verifies the package-versioned manifest and
+every file hash, refuses either existing target without overwriting, and does
+not provide force, update, uninstall, or another Host mode. Restart Codex
+after installation so it can load the Skills.
+
+Neither `pnpm add`, `pnpm install`, nor `openapi init` installs Skills.
+`openapi init` still only initializes generation configuration and the state
+ignore rule. The Skill installer does not configure MCP; after restarting,
+use `openapi-to-setup` to inspect and configure the project and Host through
+its separate approval boundary.
+
 ## Usage 
 ```json [package.json]
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,6 +16,27 @@ Install the aggregate package:
 pnpm add -D openapi-to
 ```
 
+The installed npm package also contains version-matched
+`openapi-to-setup` and `openapi-to-generate` assets. Codex users can preview
+and explicitly install them without a network request:
+
+```sh
+pnpm exec openapi skills install \
+  --host codex \
+  --dry-run
+
+pnpm exec openapi skills install \
+  --host codex
+```
+
+The only supported installer Host is `codex`. It writes to
+`$CODEX_HOME/skills`, or `~/.codex/skills` when `CODEX_HOME` is unset, and
+refuses to overwrite either existing Skill directory. Restart Codex after
+installation. Installing `openapi-to` does not install Skills automatically,
+and `openapi init` continues to initialize only the generation config and
+state ignore rule. The installer does not configure MCP; use
+`openapi-to-setup` after restart for project and Host diagnosis/configuration.
+
 The binary names are aliases:
 
 ```sh

--- a/docs/setup-skill.md
+++ b/docs/setup-skill.md
@@ -18,6 +18,29 @@ diagnosis, and 3/8/10 Tool-mode validation. A vague setup request defaults to
 `read-only`. `write-enabled` is explicit and retains prompt approval for
 `openapi_apply_generation`.
 
+## Install this Skill in Codex
+
+An installed `openapi-to` npm package carries version-matched copies of this
+Skill and `openapi-to-generate`. Preview and then explicitly install those
+offline assets:
+
+```sh
+pnpm exec openapi skills install \
+  --host codex \
+  --dry-run
+
+pnpm exec openapi skills install \
+  --host codex
+```
+
+The command writes to `$CODEX_HOME/skills`, defaulting to
+`~/.codex/skills`, and refuses to overwrite either existing Skill. Restart
+Codex after installation. This installer does not configure MCP or a project;
+once Codex reloads the Skill, this setup workflow performs that diagnosis and
+keeps every project/Host write behind its normal Setup Plan approval.
+Installing the npm package and running `openapi init` do not install Skills;
+`openapi init` remains generation-config initialization only.
+
 ## Diagnose before changing anything
 
 The Skill's standard-library inspector reads bounded project metadata without

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -36,19 +36,41 @@ this page's API call with openapi-to”. Do not use it for pure frontend work or
 for changing this Monorepo's MCP, CLI, Core, plugins, or release process.
 
 The repository keeps one authoritative source per Skill under `.agents/skills/`.
-Point a compatible Agent Skills installer at this repository and select
-`openapi-to-setup` or `openapi-to-generate`; do not copy or maintain a second
-source tree inside this repository. Interface metadata lives beside each Skill
-in `agents/openai.yaml`. The canonical GitHub directories are:
+The npm build derives versioned distribution assets from those directories;
+there is no second maintained source tree. Interface metadata lives beside
+each Skill in `agents/openai.yaml`. The canonical GitHub directories remain:
 
 ```text
 https://github.com/Vc-great/openapi-to/tree/main/.agents/skills/openapi-to-generate
 https://github.com/Vc-great/openapi-to/tree/main/.agents/skills/openapi-to-setup
 ```
 
-Installer commands and discovery behavior vary by Agent Host. Use a compatible
-Host's supported Skill installation flow; do not assume every Host accepts the
-same command.
+After installing the aggregate npm package, Codex users can preview and
+explicitly install the two assets carried by that exact package:
+
+```sh
+pnpm exec openapi skills install \
+  --host codex \
+  --dry-run
+
+pnpm exec openapi skills install \
+  --host codex
+```
+
+This command is offline and currently supports only Codex. It verifies the
+package version, manifest, and every packaged file before writing
+`$CODEX_HOME/skills/openapi-to-setup` and
+`$CODEX_HOME/skills/openapi-to-generate`; the default root is
+`~/.codex/skills`. If either target already exists, the command fails before
+writing and never overwrites or merges. Restart Codex after installation.
+There is no update, uninstall, force, project-level, Claude Code, Cursor, or
+generic Host installer in this phase.
+
+The npm install and `openapi init` remain unchanged and never install Skills
+implicitly. `openapi init` still owns only generation-config initialization
+and the state ignore rule. The Skill installer does not configure MCP. After
+restart, invoke `openapi-to-setup` so its separate Setup Plan can diagnose or
+configure the consuming project and Codex Host.
 
 ## Consumer prerequisites
 

--- a/docs/testing/consumer-acceptance-matrix.md
+++ b/docs/testing/consumer-acceptance-matrix.md
@@ -33,6 +33,10 @@ Owner names used below:
 | Packed dependency override | `release:smoke` | `test:consumer:codegen` | Yes | Yes | Linux CI | Both reuse `createPackedOverrides`; there is no second override implementation. |
 | Aggregate-only install | `release:smoke` | publication-manifest smoke | Yes | Yes | Linux CI | Installs only `openapi-to` while forcing all transitive workspace packages to the same tarball set. |
 | Installed CLI bins | `release:smoke` | `test:consumer:codegen`, A1 binary checks | Yes | Yes | Linux packed; A1 source builds on all OSes | Verifies installed `openapi` and `openapi-to`; A1 is portability evidence, not packed acceptance. |
+| Versioned consumer Skill assets | `release:smoke` | asset-builder Node tests, package-surface contract | Yes | Yes | Linux packed; deterministic builder tests on local/CI host | The single CLI tarball carries both Skills plus a version-bound manifest; the repository `.agents/skills` directories remain authoritative and are explicit Turbo cache inputs. |
+| Codex Skill installer dry-run | `release:smoke` | focused installer tests, A1 built-bin smoke | Yes | Yes | Linux packed; source-built aliases on Ubuntu/macOS/Windows | Uses isolated Host and notifier homes with spaces; human and JSON dry-runs must create neither and the aggregate wrapper must not run update-notifier. |
+| Codex Skill installer commit/rollback | focused installer tests | `release:smoke`, A1 built-bin smoke | Packed in secondary | Temporary project | Yes: A1 | Unit coverage injects copy, staging, concurrent target creation/replacement, rollback, and destination-identity failures. Atomic target reservations never overwrite an appearing destination; interrupted owned targets recover through a bounded journal and ownership marker, including reporting success when both targets had already committed. Packed smoke verifies both installed Skill trees byte-for-byte. |
+| Codex Skill existing-destination rejection | `release:smoke` | focused installer tests, A1 built-bin smoke | Yes | Yes | Linux packed; source-built aliases on Ubuntu/macOS/Windows | A second invocation exits nonzero and leaves all installed bytes unchanged. |
 | Installed MCP bin | `release:smoke` | MCP stdio E2E, A1 binary checks | Yes | Yes | Linux packed; MCP/A1 smoke on all OSes | Covers aggregate wrapper and independently installed MCP package path. |
 | ESM/CJS exports | `release:smoke` | package unit tests | Yes | Yes | Linux CI | Tests aggregate and direct package exports from installed tarballs. |
 | TypeScript package surface | `release:smoke` | package typechecks | Yes | Yes | Linux CI | Strictly compiles public imports from the installed package set. |
@@ -68,6 +72,14 @@ scenario and all packed package/MCP checks, and runs the Setup-to-MCP bridge in
 the already installed external consumer. The bridge uses the Setup Inspector
 from the exact repository checkout and the MCP runtime installed from that
 checkout's tarballs. The Inspector is not claimed to ship in an npm package.
+
+The same one-pack run installs the aggregate tarball, resolves the transitive
+CLI package's versioned Skill assets, runs a human dry-run with update-notifier
+fully enabled but isolated and proves it creates neither Host nor notifier
+state, repeats the machine-readable dry-run, installs both Skills, compares
+installed hashes with packaged bytes, and proves a second install fails without
+mutation. Restart Codex remains a documented user action; CI does not model
+Host UI restart behavior.
 
 The bridge proves only:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,12 +41,14 @@
 		"!/**/__tests__/**"
 	],
 	"scripts": {
-		"build": "pnpm exec tsup",
+		"build": "pnpm exec tsup && node ../../scripts/build-consumer-skill-assets.mjs",
 		"clean": "pnpm exec rimraf ./dist",
 		"lint": "pnpm exec biome lint .",
 		"lint:fix": "pnpm exec biome lint --write --unsafe .",
+		"prepack": "pnpm run build",
 		"start": "pnpm exec tsup --watch",
 		"test": "pnpm exec vitest run --passWithNoTests",
+		"test:skills-installer": "pnpm exec vitest run src/skillsInstall.test.ts",
 		"typecheck": "pnpm exec tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
 	},
 	"dependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,12 @@ import path from "node:path";
 import { version } from "../../openapi/package.json";
 import { generate } from "./generate.ts";
 import { init } from "./init.ts";
+import {
+	SkillsInstallError,
+	installCodexSkills,
+	parseSkillsInstallRequest,
+	skillsInstallHumanOutput,
+} from "./skillsInstall.ts";
 
 const moduleName = "openapi";
 
@@ -444,6 +450,46 @@ async function runDiff(
 	};
 }
 
+async function runSkillsInstall(
+	action: unknown,
+	options: Record<string, unknown>,
+	io: CLIIO,
+): Promise<CLIRunResult> {
+	const json = options.json === true;
+	try {
+		const request = parseSkillsInstallRequest(action, options);
+		const output = await installCodexSkills(request, version);
+		if (json) printJSON(io, output);
+		else {
+			for (const line of skillsInstallHumanOutput(output)) io.stdout(line);
+		}
+		return { exitCode: ExitCode.Success, output };
+	} catch (error) {
+		const diagnostics: Diagnostic[] = [
+			{
+				code:
+					error instanceof SkillsInstallError
+						? error.code
+						: "SKILLS_INSTALL_FAILED",
+				severity: "error",
+				message:
+					error instanceof SkillsInstallError
+						? error.message
+						: "Codex Skill installation failed safely.",
+			},
+		];
+		const output = {
+			success: false,
+			command: "skills install",
+			diagnostics,
+			summary: summarizeDiagnostics(diagnostics),
+		};
+		if (json) printJSON(io, output);
+		else printDiagnostics(io, diagnostics);
+		return { exitCode: ExitCode.GeneralError, output };
+	}
+}
+
 export async function run(
 	argv: string[] = process.argv,
 	io: CLIIO = defaultIO,
@@ -459,6 +505,18 @@ export async function run(
 		.command("init", "Generate a root openapi.config file")
 		.action(async () => {
 			await init();
+		});
+	program
+		.command("skills <action>", "Manage packaged Agent Skills")
+		.usage("skills install --host codex [--dry-run] [--json]")
+		.option(
+			"--host [host]",
+			"Install for the selected Host (currently codex only)",
+		)
+		.option("--dry-run", "Preview the exact install plan without writing")
+		.option("--json", "Write JSON to stdout")
+		.action(async (action, options) => {
+			actionResult = await runSkillsInstall(action, options, io);
 		});
 	program
 		.command("generate", "Generate code from an openapi.config file")

--- a/packages/cli/src/skillsInstall.test.ts
+++ b/packages/cli/src/skillsInstall.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+	cp,
 	lstat,
 	mkdir,
 	mkdtemp,
@@ -103,6 +104,24 @@ describe.sequential("Codex Skill installer", () => {
 		vi.restoreAllMocks();
 		await rm(root, { recursive: true, force: true });
 	});
+
+	async function createRetainedTransaction(nonce: string) {
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				processId: 999_999,
+				transactionNonce: () => nonce,
+				beforeTargetCommit: async (skill) => {
+					if (skill === "openapi-to-setup") {
+						throw new Error("retain transaction after first target");
+					}
+				},
+				beforeTargetRollback: async () => {
+					throw new Error("retain transaction for recovery");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+	}
 
 	it("requires exactly --host codex and rejects unsupported actions", () => {
 		expect(() => parseSkillsInstallRequest("install", {})).toThrowError(
@@ -439,6 +458,424 @@ describe.sequential("Codex Skill installer", () => {
 		await expect(
 			readFile(path.join(displaced, "SKILL.md"), "utf8"),
 		).resolves.toContain("openapi-to-generate");
+	});
+
+	it("preserves a replaced staging directory during normal failure cleanup", async () => {
+		const nonce = "replaced-normal-staging";
+		const skillsRoot = path.join(codexHome, "skills");
+		const stagingRoot = path.join(
+			skillsRoot,
+			`.openapi-to-skills-install-${nonce}`,
+		);
+		const sentinel = path.join(stagingRoot, "foreign-sentinel.txt");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				transactionNonce: () => nonce,
+				beforeTargetCommit: async (_skill, index) => {
+					if (index !== 0) return;
+					await rm(stagingRoot, { recursive: true, force: false });
+					await mkdir(stagingRoot);
+					await writeFile(sentinel, "preserved\n");
+					throw new Error("fail after replacing staging");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(await readFile(sentinel, "utf8")).toBe("preserved\n");
+		await expect(lstat(stagingRoot)).resolves.toMatchObject({});
+		await expect(
+			lstat(path.join(skillsRoot, ".openapi-to-skills-install.lock")),
+		).resolves.toMatchObject({});
+	});
+
+	it("preserves a replaced staging directory during interrupted recovery", async () => {
+		const nonce = "replaced-recovery-staging";
+		const skillsRoot = path.join(codexHome, "skills");
+		const stagingRoot = path.join(
+			skillsRoot,
+			`.openapi-to-skills-install-${nonce}`,
+		);
+		const sentinel = path.join(stagingRoot, "foreign-sentinel.txt");
+		await createRetainedTransaction(nonce);
+		await rm(stagingRoot, { recursive: true, force: false });
+		await mkdir(stagingRoot);
+		await writeFile(sentinel, "preserved\n");
+
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(await readFile(sentinel, "utf8")).toBe("preserved\n");
+		await expect(lstat(stagingRoot)).resolves.toMatchObject({});
+	});
+
+	it("preserves a staging replacement introduced after normal cleanup verification", async () => {
+		const nonce = "replace-after-normal-verification";
+		const skillsRoot = path.join(codexHome, "skills");
+		const stagingRoot = path.join(
+			skillsRoot,
+			`.openapi-to-skills-install-${nonce}`,
+		);
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		const quarantineRoot = path.join(lockPath, "staging-quarantine");
+		const displaced = path.join(root, "verified-normal-staging");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				transactionNonce: () => nonce,
+				beforeTargetCommit: async (_skill, index) => {
+					if (index === 0) throw new Error("start normal cleanup");
+				},
+				beforeStagingDetach: async () => {
+					await rename(stagingRoot, displaced);
+					await mkdir(stagingRoot);
+					await writeFile(
+						path.join(stagingRoot, "foreign-sentinel.txt"),
+						"preserved\n",
+					);
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(
+			await readFile(path.join(quarantineRoot, "foreign-sentinel.txt"), "utf8"),
+		).toBe("preserved\n");
+		await expect(
+			readFile(
+				path.join(displaced, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+		await expect(lstat(lockPath)).resolves.toMatchObject({});
+	});
+
+	it("preserves a staging replacement introduced after recovery verification", async () => {
+		const nonce = "replace-after-recovery-verification";
+		const skillsRoot = path.join(codexHome, "skills");
+		const stagingRoot = path.join(
+			skillsRoot,
+			`.openapi-to-skills-install-${nonce}`,
+		);
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		const quarantineRoot = path.join(lockPath, "staging-quarantine");
+		const displaced = path.join(root, "verified-recovery-staging");
+		await createRetainedTransaction(nonce);
+
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				{
+					...dependencies,
+					beforeStagingDetach: async () => {
+						await rename(stagingRoot, displaced);
+						await mkdir(stagingRoot);
+						await writeFile(
+							path.join(stagingRoot, "foreign-sentinel.txt"),
+							"preserved\n",
+						);
+					},
+				},
+			),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(
+			await readFile(path.join(quarantineRoot, "foreign-sentinel.txt"), "utf8"),
+		).toBe("preserved\n");
+		await expect(
+			readFile(
+				path.join(displaced, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+		await expect(lstat(lockPath)).resolves.toMatchObject({});
+	});
+
+	it("preserves an exact staging replacement introduced after quarantine verification", async () => {
+		const nonce = "replace-after-quarantine-verification";
+		const skillsRoot = path.join(codexHome, "skills");
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		const quarantineRoot = path.join(lockPath, "staging-quarantine");
+		const displaced = path.join(root, "verified-quarantine-staging");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				transactionNonce: () => nonce,
+				beforeTargetCommit: async (_skill, index) => {
+					if (index === 0) throw new Error("start quarantine cleanup");
+				},
+				beforeQuarantineCleanup: async () => {
+					await rename(quarantineRoot, displaced);
+					await cp(displaced, quarantineRoot, { recursive: true });
+					await writeFile(
+						path.join(quarantineRoot, "foreign-sentinel.txt"),
+						"preserved\n",
+					);
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(
+			await readFile(path.join(quarantineRoot, "foreign-sentinel.txt"), "utf8"),
+		).toBe("preserved\n");
+		await expect(
+			readFile(
+				path.join(quarantineRoot, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+		await expect(
+			readFile(
+				path.join(displaced, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+	});
+
+	it("preserves a recovery replacement introduced after quarantine verification", async () => {
+		const nonce = "recovery-replace-after-quarantine";
+		const skillsRoot = path.join(codexHome, "skills");
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		const quarantineRoot = path.join(lockPath, "staging-quarantine");
+		const displaced = path.join(root, "recovery-verified-quarantine-staging");
+		await createRetainedTransaction(nonce);
+
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				{
+					...dependencies,
+					beforeQuarantineCleanup: async () => {
+						await rename(quarantineRoot, displaced);
+						await cp(displaced, quarantineRoot, { recursive: true });
+						await writeFile(
+							path.join(quarantineRoot, "foreign-sentinel.txt"),
+							"preserved\n",
+						);
+					},
+				},
+			),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(
+			await readFile(path.join(quarantineRoot, "foreign-sentinel.txt"), "utf8"),
+		).toBe("preserved\n");
+		await expect(
+			readFile(
+				path.join(quarantineRoot, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+		await expect(
+			readFile(
+				path.join(displaced, "openapi-to-generate", "SKILL.md"),
+				"utf8",
+			),
+		).resolves.toContain("openapi-to-generate");
+	});
+
+	it("rejects an old or incomplete interrupted transaction journal", async () => {
+		const nonce = "old-journal-schema";
+		const skillsRoot = path.join(codexHome, "skills");
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		await createRetainedTransaction(nonce);
+		const journalPath = path.join(lockPath, "transaction.json");
+		const journal = JSON.parse(await readFile(journalPath, "utf8"));
+		journal.schemaVersion = 1;
+		delete journal.stagingOwnerMarker;
+		await writeFile(journalPath, `${JSON.stringify(journal, null, 2)}\n`);
+
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		await expect(
+			lstat(
+				path.join(skillsRoot, `.openapi-to-skills-install-${nonce}`),
+			),
+		).resolves.toMatchObject({});
+		await expect(lstat(lockPath)).resolves.toMatchObject({});
+	});
+
+	it.each([
+		{
+			name: "a missing staging owner marker",
+			mutate: async ({
+				stagingRoot,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await rm(path.join(stagingRoot, ".openapi-to-staging-owner"));
+			},
+		},
+		{
+			name: "a staging owner marker with the wrong nonce",
+			mutate: async ({
+				stagingRoot,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await writeFile(
+					path.join(stagingRoot, ".openapi-to-staging-owner"),
+					"openapi-to-staging:wrong-nonce\n",
+				);
+			},
+		},
+		{
+			name: "an unexplained staging file",
+			mutate: async ({
+				stagingRoot,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await writeFile(path.join(stagingRoot, "foreign.txt"), "preserved\n");
+			},
+		},
+		{
+			name: "an unexplained staging directory",
+			mutate: async ({
+				stagingRoot,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await mkdir(path.join(stagingRoot, "foreign-directory"));
+			},
+		},
+		{
+			name: "a missing staging ownership record",
+			mutate: async ({
+				lockPath,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await rm(path.join(lockPath, "staging-owner.json"));
+			},
+		},
+		{
+			name: "a corrupted staging ownership record",
+			mutate: async ({
+				lockPath,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				await writeFile(path.join(lockPath, "staging-owner.json"), "{\n");
+			},
+		},
+		{
+			name: "a persisted staging identity mismatch",
+			mutate: async ({
+				lockPath,
+			}: {
+				stagingRoot: string;
+				lockPath: string;
+			}) => {
+				const recordPath = path.join(lockPath, "staging-owner.json");
+				const record = JSON.parse(await readFile(recordPath, "utf8"));
+				record.stagingIdentity.inode = (
+					BigInt(record.stagingIdentity.inode) + 1n
+				).toString();
+				await writeFile(recordPath, `${JSON.stringify(record, null, 2)}\n`);
+			},
+		},
+	])("fails closed for $name", async ({ mutate }) => {
+		const nonce = "tampered-staging";
+		const skillsRoot = path.join(codexHome, "skills");
+		const stagingRoot = path.join(
+			skillsRoot,
+			`.openapi-to-skills-install-${nonce}`,
+		);
+		const lockPath = path.join(
+			skillsRoot,
+			".openapi-to-skills-install.lock",
+		);
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				transactionNonce: () => nonce,
+				beforeTargetCommit: async (_skill, index) => {
+					if (index !== 0) return;
+					await mutate({ stagingRoot, lockPath });
+					throw new Error("fail after tampering with staging ownership");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		await expect(lstat(stagingRoot)).resolves.toMatchObject({});
+		await expect(lstat(lockPath)).resolves.toMatchObject({});
+	});
+
+	it("fails closed for staging ownership symlinks without following them", async (t) => {
+		if (process.platform === "win32") {
+			t.skip();
+			return;
+		}
+		for (const target of ["staging", "marker", "record"] as const) {
+			const nonce = `symlink-${target}`;
+			const skillsRoot = path.join(codexHome, "skills");
+			const stagingRoot = path.join(
+				skillsRoot,
+				`.openapi-to-skills-install-${nonce}`,
+			);
+			const external = path.join(root, `external-${target}`);
+			await mkdir(external);
+			await writeFile(path.join(external, "sentinel.txt"), "preserved\n");
+			await expect(
+				installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+					...dependencies,
+					transactionNonce: () => nonce,
+					beforeTargetCommit: async (_skill, index) => {
+						if (index !== 0) return;
+						if (target === "staging") {
+							await rm(stagingRoot, { recursive: true, force: false });
+							await symlink(external, stagingRoot, "dir");
+						} else if (target === "marker") {
+							const marker = path.join(
+								stagingRoot,
+								".openapi-to-staging-owner",
+							);
+							await rm(marker);
+							await symlink(path.join(external, "sentinel.txt"), marker);
+						} else {
+							const record = path.join(
+								skillsRoot,
+								".openapi-to-skills-install.lock",
+								"staging-owner.json",
+							);
+							await rm(record);
+							await symlink(path.join(external, "sentinel.txt"), record);
+						}
+						throw new Error("fail after adding staging symlink");
+					},
+				}),
+			).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+			expect(await readFile(path.join(external, "sentinel.txt"), "utf8")).toBe(
+				"preserved\n",
+			);
+			await rm(codexHome, { recursive: true, force: true });
+		}
 	});
 
 	it("cleans staging and destinations after a copy failure", async () => {

--- a/packages/cli/src/skillsInstall.test.ts
+++ b/packages/cli/src/skillsInstall.test.ts
@@ -1,0 +1,700 @@
+import { createHash } from "node:crypto";
+import {
+	lstat,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ExitCode } from "@openapi-to/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+	buildConsumerSkillAssets,
+	consumerSkillNames,
+} from "../../../scripts/build-consumer-skill-assets.mjs";
+import { type CLIIO, run } from "./index.ts";
+import {
+	installCodexSkills,
+	parseSkillsInstallRequest,
+	SkillsInstallError,
+	skillsInstallHumanOutput,
+} from "./skillsInstall.ts";
+
+const repositoryRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"../../..",
+);
+const packageVersion = "9.8.7-test";
+
+async function filesBelow(root: string, relativeDirectory = "") {
+	const directory = path.join(
+		root,
+		...relativeDirectory.split("/").filter(Boolean),
+	);
+	const entries = (await readdir(directory, { withFileTypes: true })).sort(
+		(left, right) =>
+			left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+	);
+	const files: Array<{ path: string; bytes: Buffer; sha256: string }> = [];
+	for (const entry of entries) {
+		const relativePath = relativeDirectory
+			? `${relativeDirectory}/${entry.name}`
+			: entry.name;
+		if (entry.isDirectory()) {
+			files.push(...(await filesBelow(root, relativePath)));
+		} else if (entry.isFile()) {
+			const bytes = await readFile(path.join(root, ...relativePath.split("/")));
+			files.push({
+				path: relativePath,
+				bytes,
+				sha256: createHash("sha256").update(bytes).digest("hex"),
+			});
+		}
+	}
+	return files;
+}
+
+describe.sequential("Codex Skill installer", () => {
+	let root: string;
+	let assetRoot: string;
+	let codexHome: string;
+	let dependencies: {
+		assetRoot: string;
+		environment: NodeJS.ProcessEnv;
+		homeDirectory: () => string;
+	};
+
+	beforeEach(async () => {
+		root = await mkdtemp(path.join(os.tmpdir(), "openapi-to-skills-install-"));
+		const packageDirectory = path.join(root, "package");
+		assetRoot = path.join(root, "assets");
+		codexHome = path.join(root, "Codex Home 空格");
+		await mkdir(packageDirectory, { recursive: true });
+		await writeFile(
+			path.join(packageDirectory, "package.json"),
+			`${JSON.stringify({
+				name: "@openapi-to/cli",
+				version: packageVersion,
+			})}\n`,
+		);
+		await buildConsumerSkillAssets({
+			sourceRoot: path.join(repositoryRoot, ".agents", "skills"),
+			packageDirectory,
+			outputDirectory: assetRoot,
+		});
+		dependencies = {
+			assetRoot,
+			environment: { CODEX_HOME: codexHome },
+			homeDirectory: () => path.join(root, "unused-home"),
+		};
+	});
+
+	afterEach(async () => {
+		process.exitCode = 0;
+		vi.restoreAllMocks();
+		await rm(root, { recursive: true, force: true });
+	});
+
+	it("requires exactly --host codex and rejects unsupported actions", () => {
+		expect(() => parseSkillsInstallRequest("install", {})).toThrowError(
+			expect.objectContaining({ code: "SKILLS_HOST_REQUIRED" }),
+		);
+		expect(() =>
+			parseSkillsInstallRequest("install", { host: true }),
+		).toThrowError(expect.objectContaining({ code: "SKILLS_HOST_EMPTY" }));
+		expect(() =>
+			parseSkillsInstallRequest("install", { host: ["codex", "codex"] }),
+		).toThrowError(expect.objectContaining({ code: "SKILLS_HOST_DUPLICATE" }));
+		expect(() =>
+			parseSkillsInstallRequest("install", { host: "cursor" }),
+		).toThrowError(
+			expect.objectContaining({ code: "SKILLS_HOST_UNSUPPORTED" }),
+		);
+		expect(() =>
+			parseSkillsInstallRequest("update", { host: "codex" }),
+		).toThrowError(
+			expect.objectContaining({ code: "SKILLS_ACTION_UNSUPPORTED" }),
+		);
+		expect(
+			parseSkillsInstallRequest("install", {
+				host: "codex",
+				dryRun: true,
+				json: true,
+			}),
+		).toEqual({ dryRun: true, json: true });
+	});
+
+	it("dry-runs with an exact JSON-ready plan and creates no CODEX_HOME", async () => {
+		const output = await installCodexSkills(
+			{ dryRun: true, json: true },
+			packageVersion,
+			dependencies,
+		);
+		expect(output).toMatchObject({
+			success: true,
+			command: "skills install",
+			mode: "dry-run",
+			host: "codex",
+			packageVersion,
+			source: "packaged-npm-assets",
+			destinationRoot: path.join(codexHome, "skills"),
+			skills: consumerSkillNames,
+			installed: [],
+			restartRequired: true,
+		});
+		expect(output.actions).toEqual(
+			consumerSkillNames.map((skill) => ({
+				action: "install",
+				skill,
+				destination: path.join(codexHome, "skills", skill),
+			})),
+		);
+		expect(JSON.parse(JSON.stringify(output))).toEqual(output);
+		await expect(lstat(codexHome)).rejects.toMatchObject({ code: "ENOENT" });
+		expect(skillsInstallHumanOutput(output)).toContain(
+			"No files were written.",
+		);
+		expect(skillsInstallHumanOutput(output).join("\n")).not.toContain(root);
+	});
+
+	it("installs both Skills, verifies every byte, and requires restart", async () => {
+		const output = await installCodexSkills(
+			{ dryRun: false, json: true },
+			packageVersion,
+			dependencies,
+		);
+		expect(output).toMatchObject({
+			mode: "install",
+			installed: consumerSkillNames,
+			restartRequired: true,
+		});
+		for (const name of consumerSkillNames) {
+			const packaged = await filesBelow(path.join(assetRoot, name));
+			const installed = await filesBelow(path.join(codexHome, "skills", name));
+			expect(installed.map(({ path, sha256 }) => ({ path, sha256 }))).toEqual(
+				packaged.map(({ path, sha256 }) => ({ path, sha256 })),
+			);
+			for (const [index, file] of installed.entries()) {
+				expect(file.bytes).toEqual(packaged.at(index)?.bytes);
+			}
+		}
+		expect(await readdir(path.join(codexHome, "skills"))).toEqual(
+			consumerSkillNames,
+		);
+		expect(skillsInstallHumanOutput(output)).toContain("restartRequired: true");
+	});
+
+	it("fails before writing when either destination already exists", async () => {
+		for (const conflict of consumerSkillNames) {
+			await rm(codexHome, { recursive: true, force: true });
+			const skillsRoot = path.join(codexHome, "skills");
+			await mkdir(path.join(skillsRoot, conflict), { recursive: true });
+			await writeFile(
+				path.join(skillsRoot, conflict, "sentinel.txt"),
+				"preserved\n",
+			);
+			const before = await filesBelow(codexHome);
+			await expect(
+				installCodexSkills(
+					{ dryRun: false, json: true },
+					packageVersion,
+					dependencies,
+				),
+			).rejects.toMatchObject({ code: "SKILLS_DESTINATION_CONFLICT" });
+			const after = await filesBelow(codexHome);
+			expect(after).toEqual(before);
+			const other = consumerSkillNames.find((name) => name !== conflict);
+			expect(other).toBeDefined();
+			await expect(
+				lstat(path.join(skillsRoot, String(other))),
+			).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+		}
+	});
+
+	it("rejects a destination symlink without following or modifying it", async (t) => {
+		const skillsRoot = path.join(codexHome, "skills");
+		const external = path.join(root, "external");
+		await Promise.all([
+			mkdir(skillsRoot, { recursive: true }),
+			mkdir(external, { recursive: true }),
+		]);
+		try {
+			await symlink(
+				external,
+				path.join(skillsRoot, "openapi-to-generate"),
+				process.platform === "win32" ? "junction" : "dir",
+			);
+		} catch (error) {
+			if (
+				process.platform === "win32" &&
+				["EPERM", "EACCES"].includes(
+					(error as NodeJS.ErrnoException).code ?? "",
+				)
+			) {
+				t.skip();
+				return;
+			}
+			throw error;
+		}
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_CONFLICT" });
+		expect(await readdir(external)).toEqual([]);
+	});
+
+	it("rolls back the first committed Skill when the second commit fails", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				beforeTargetCommit: async (skill) => {
+					if (skill === "openapi-to-setup") {
+						throw new Error("injected second commit failure");
+					}
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_FAILED" });
+		for (const name of consumerSkillNames) {
+			await expect(lstat(path.join(skillsRoot, name))).rejects.toMatchObject({
+				code: "ENOENT",
+			});
+		}
+		await expect(lstat(skillsRoot)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("never overwrites a target that appears during commit", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				beforeTargetCommit: async (skill) => {
+					if (skill === "openapi-to-generate") {
+						await mkdir(path.join(skillsRoot, skill));
+					}
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_CONFLICT" });
+		expect(await readdir(path.join(skillsRoot, "openapi-to-generate"))).toEqual(
+			[],
+		);
+		await expect(
+			lstat(path.join(skillsRoot, "openapi-to-setup")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+		expect(await readdir(skillsRoot)).toEqual(["openapi-to-generate"]);
+	});
+
+	it("recovers a retained transaction before retrying the complete install", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		const processId = 999_999;
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				processId,
+				beforeTargetCommit: async (skill) => {
+					if (skill === "openapi-to-setup") {
+						throw new Error("injected second commit failure");
+					}
+				},
+				beforeTargetRollback: async (skill) => {
+					if (skill === "openapi-to-generate") {
+						throw new Error("injected rollback failure");
+					}
+				},
+				transactionNonce: () => "retained-transaction",
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		await expect(
+			lstat(path.join(skillsRoot, "openapi-to-generate")),
+		).resolves.toBeDefined();
+		await expect(
+			lstat(path.join(skillsRoot, "openapi-to-setup")),
+		).rejects.toMatchObject({ code: "ENOENT" });
+
+		const output = await installCodexSkills(
+			{ dryRun: false, json: true },
+			packageVersion,
+			dependencies,
+		);
+		expect(output.installed).toEqual(consumerSkillNames);
+		expect((await readdir(skillsRoot)).sort()).toEqual(consumerSkillNames);
+	});
+
+	it("recovers a partially materialized owned target before retrying", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		const destination = path.join(skillsRoot, "openapi-to-generate");
+		let injected = false;
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				processId: 999_999,
+				transactionNonce: () => "partial-owned-target",
+				writeFile: async (...arguments_) => {
+					const target = String(arguments_[0]);
+					if (
+						!injected &&
+						target.startsWith(`${destination}${path.sep}`) &&
+						path.basename(target) !== ".openapi-to-install-owner"
+					) {
+						injected = true;
+						throw new Error("injected target copy failure");
+					}
+					return writeFile(...arguments_);
+				},
+				beforeTargetRollback: async () => {
+					throw new Error("retain transaction for recovery");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(injected).toBe(true);
+		expect(await readdir(destination)).toContain(".openapi-to-install-owner");
+
+		const output = await installCodexSkills(
+			{ dryRun: false, json: true },
+			packageVersion,
+			dependencies,
+		);
+		expect(output.installed).toEqual(consumerSkillNames);
+		expect((await readdir(skillsRoot)).sort()).toEqual(consumerSkillNames);
+	});
+
+	it("reports success when retrying a fully committed interrupted transaction", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				processId: 999_999,
+				transactionNonce: () => "complete-owned-targets",
+				afterTargetCommit: async (_skill, index) => {
+					if (index === consumerSkillNames.length - 1) {
+						throw new Error("injected interruption after complete commit");
+					}
+				},
+				beforeTargetRollback: async () => {
+					throw new Error("retain completed transaction for recovery");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect((await readdir(skillsRoot)).sort()).toEqual([
+			".openapi-to-skills-install-complete-owned-targets",
+			".openapi-to-skills-install.lock",
+			...consumerSkillNames,
+		]);
+
+		const output = await installCodexSkills(
+			{ dryRun: false, json: true },
+			packageVersion,
+			dependencies,
+		);
+		expect(output).toMatchObject({
+			success: true,
+			mode: "install",
+			installed: consumerSkillNames,
+			restartRequired: true,
+		});
+		expect((await readdir(skillsRoot)).sort()).toEqual(consumerSkillNames);
+	});
+
+	it("preserves a replaced target during rollback for manual recovery", async () => {
+		const skillsRoot = path.join(codexHome, "skills");
+		const displaced = path.join(codexHome, "displaced-owned-skill");
+		const replacement = path.join(skillsRoot, "openapi-to-generate");
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				beforeTargetCommit: async (skill) => {
+					if (skill === "openapi-to-setup") {
+						throw new Error("injected second commit failure");
+					}
+				},
+				beforeTargetRollback: async (skill) => {
+					if (skill === "openapi-to-generate") {
+						await rename(replacement, displaced);
+						await mkdir(replacement);
+						await writeFile(
+							path.join(replacement, "foreign.txt"),
+							"preserved\n",
+						);
+					}
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_RECOVERY_REQUIRED" });
+		expect(await readFile(path.join(replacement, "foreign.txt"), "utf8")).toBe(
+			"preserved\n",
+		);
+		await expect(
+			readFile(path.join(displaced, "SKILL.md"), "utf8"),
+		).resolves.toContain("openapi-to-generate");
+	});
+
+	it("cleans staging and destinations after a copy failure", async () => {
+		let writes = 0;
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				writeFile: async (...arguments_) => {
+					writes += 1;
+					if (writes === 2) throw new Error("injected copy failure");
+					return writeFile(...arguments_);
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_FAILED" });
+		expect(writes).toBe(2);
+		await expect(lstat(codexHome)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("fails closed before staging without leaving a lock", async () => {
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				beforeStaging: async () => {
+					throw new Error("injected staging failure");
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_INSTALL_FAILED" });
+		await expect(lstat(codexHome)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("detects a replaced skills root before staging and never follows it", async (t) => {
+		const skillsRoot = path.join(codexHome, "skills");
+		const displaced = path.join(codexHome, "displaced-skills");
+		const external = path.join(root, "external-race-target");
+		await mkdir(external);
+		let swapped = false;
+		await expect(
+			installCodexSkills({ dryRun: false, json: true }, packageVersion, {
+				...dependencies,
+				beforeStaging: async () => {
+					await rename(skillsRoot, displaced);
+					try {
+						await symlink(
+							external,
+							skillsRoot,
+							process.platform === "win32" ? "junction" : "dir",
+						);
+					} catch (error) {
+						if (
+							process.platform === "win32" &&
+							["EPERM", "EACCES"].includes(
+								(error as NodeJS.ErrnoException).code ?? "",
+							)
+						) {
+							await rename(displaced, skillsRoot);
+							t.skip();
+							return;
+						}
+						throw error;
+					}
+					swapped = true;
+				},
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_CHANGED" });
+		if (!swapped) return;
+		expect(await readdir(external)).toEqual([]);
+		expect(await readdir(displaced)).toEqual([
+			".openapi-to-skills-install.lock",
+		]);
+	});
+
+	it("fails closed for missing, malformed, mismatched, or corrupted manifests", async () => {
+		const manifestPath = path.join(assetRoot, "manifest.json");
+		const original = await readFile(manifestPath);
+		for (const mutation of [
+			async () => rm(manifestPath),
+			async () => writeFile(manifestPath, "{"),
+			async () =>
+				writeFile(
+					manifestPath,
+					original.toString().replace(packageVersion, "wrong-version"),
+				),
+		]) {
+			await writeFile(manifestPath, original);
+			await mutation();
+			await expect(
+				installCodexSkills(
+					{ dryRun: true, json: true },
+					packageVersion,
+					dependencies,
+				),
+			).rejects.toBeInstanceOf(SkillsInstallError);
+			await expect(lstat(codexHome)).rejects.toMatchObject({ code: "ENOENT" });
+		}
+		await writeFile(manifestPath, original);
+		const target = path.join(assetRoot, "openapi-to-generate", "SKILL.md");
+		await writeFile(target, `${await readFile(target, "utf8")}\ncorrupted\n`);
+		await expect(
+			installCodexSkills(
+				{ dryRun: true, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_ASSET_INTEGRITY_FAILED" });
+	});
+
+	it("rejects empty/relative CODEX_HOME and invalid destination roots", async () => {
+		for (const value of ["", "relative/codex"]) {
+			await expect(
+				installCodexSkills({ dryRun: true, json: true }, packageVersion, {
+					...dependencies,
+					environment: { CODEX_HOME: value },
+				}),
+			).rejects.toMatchObject({ code: "SKILLS_DESTINATION_INVALID" });
+		}
+		await writeFile(codexHome, "not a directory\n");
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_INVALID" });
+		await rm(codexHome);
+		await mkdir(codexHome);
+		await writeFile(path.join(codexHome, "skills"), "not a directory\n");
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_INVALID" });
+		await expect(
+			installCodexSkills({ dryRun: true, json: true }, packageVersion, {
+				...dependencies,
+				environment: {},
+				homeDirectory: () => "",
+			}),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_INVALID" });
+	});
+
+	it("uses ~/.codex when CODEX_HOME is unset", async () => {
+		const home = path.join(root, "User Home");
+		const output = await installCodexSkills(
+			{ dryRun: true, json: true },
+			packageVersion,
+			{
+				...dependencies,
+				environment: {},
+				homeDirectory: () => home,
+			},
+		);
+		expect(output.destinationRoot).toBe(path.join(home, ".codex", "skills"));
+		await expect(lstat(home)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rejects a second install without modifying installed bytes", async () => {
+		await installCodexSkills(
+			{ dryRun: false, json: true },
+			packageVersion,
+			dependencies,
+		);
+		const before = await filesBelow(path.join(codexHome, "skills"));
+		await expect(
+			installCodexSkills(
+				{ dryRun: false, json: true },
+				packageVersion,
+				dependencies,
+			),
+		).rejects.toMatchObject({ code: "SKILLS_DESTINATION_CONFLICT" });
+		expect(await filesBelow(path.join(codexHome, "skills"))).toEqual(before);
+	});
+});
+
+describe.sequential("skills command CLI contract", () => {
+	let stdout: string[];
+	let stderr: string[];
+	let io: CLIIO;
+
+	beforeEach(() => {
+		stdout = [];
+		stderr = [];
+		io = {
+			stdout: (message) => stdout.push(message),
+			stderr: (message) => stderr.push(message),
+		};
+	});
+
+	afterEach(() => {
+		process.exitCode = 0;
+		vi.restoreAllMocks();
+	});
+
+	it("emits stable JSON for host validation before or after the command", async () => {
+		for (const argv of [
+			["node", "openapi", "--json", "skills", "install"],
+			["node", "openapi", "skills", "install", "--host", "cursor", "--json"],
+			[
+				"node",
+				"openapi",
+				"skills",
+				"install",
+				"--host",
+				"codex",
+				"--host",
+				"codex",
+				"--json",
+			],
+		]) {
+			stdout = [];
+			stderr = [];
+			const result = await run(argv, io);
+			expect(result.exitCode).toBe(ExitCode.GeneralError);
+			expect(stderr).toEqual([]);
+			expect(JSON.parse(stdout.join("\n"))).toMatchObject({
+				success: false,
+				command: "skills install",
+				diagnostics: [{ code: expect.stringMatching(/^SKILLS_HOST_/) }],
+			});
+		}
+	});
+
+	it("rejects overwrite flags through the existing CLI error contract", async () => {
+		const result = await run(
+			[
+				"node",
+				"openapi",
+				"skills",
+				"install",
+				"--host",
+				"codex",
+				"--force",
+				"--json",
+			],
+			io,
+		);
+		expect(result.exitCode).toBe(ExitCode.GeneralError);
+		expect(stderr).toEqual([]);
+		expect(JSON.parse(stdout.join("\n"))).toMatchObject({
+			success: false,
+			diagnostics: [{ code: "CLI_EXECUTION_FAILED" }],
+		});
+	});
+
+	it("shows focused help without running the installer", async () => {
+		const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+		const result = await run(
+			["node", "openapi", "skills", "install", "--help"],
+			io,
+		);
+		expect(result.exitCode).toBe(ExitCode.Success);
+		expect(log.mock.calls.flat().join("\n")).toContain(
+			"skills install --host codex",
+		);
+		expect(stdout).toEqual([]);
+		expect(stderr).toEqual([]);
+	});
+});

--- a/packages/cli/src/skillsInstall.ts
+++ b/packages/cli/src/skillsInstall.ts
@@ -2,10 +2,12 @@ import { createHash, randomUUID } from "node:crypto";
 import { constants } from "node:fs";
 import {
 	access,
+	link,
 	lstat,
 	mkdir,
 	readdir,
 	readFile,
+	rename,
 	rm,
 	rmdir,
 	unlink,
@@ -24,7 +26,11 @@ const distributionByteLimit = 64 * 1024 * 1024;
 const installLockName = ".openapi-to-skills-install.lock";
 const installJournalName = "transaction.json";
 const stagingDirectoryPrefix = ".openapi-to-skills-install-";
+const stagingOwnerRecordName = "staging-owner.json";
+const stagingOwnerMarkerName = ".openapi-to-staging-owner";
+const stagingQuarantineName = "staging-quarantine";
 const installJournalByteLimit = 16 * 1024;
+const stagingOwnerRecordByteLimit = 4 * 1024;
 const targetOwnerMarkerName = ".openapi-to-install-owner";
 const activeTransactionNonces = new Set<string>();
 
@@ -57,17 +63,27 @@ interface VerifiedSkill {
 }
 
 interface InstallJournal {
-	schemaVersion: 1;
+	schemaVersion: 2;
 	packageVersion: string;
 	pid: number;
 	nonce: string;
 	stagingDirectory: string;
+	stagingOwnerRecord: typeof stagingOwnerRecordName;
+	stagingOwnerMarker: typeof stagingOwnerMarkerName;
+	stagingQuarantine: typeof stagingQuarantineName;
 	skills: SupportedSkillName[];
 }
 
 interface FileIdentity {
 	device: string;
 	inode: string;
+}
+
+interface StagingOwnershipRecord {
+	schemaVersion: 1;
+	nonce: string;
+	stagingDirectory: string;
+	stagingIdentity: FileIdentity;
 }
 
 interface DestinationIdentity {
@@ -92,6 +108,8 @@ export interface SkillsInstallDependencies {
 	environment?: NodeJS.ProcessEnv;
 	homeDirectory?: () => string;
 	beforeStaging?: () => Promise<void>;
+	beforeStagingDetach?: () => Promise<void>;
+	beforeQuarantineCleanup?: () => Promise<void>;
 	beforeTargetCommit?: (
 		skill: SupportedSkillName,
 		index: number,
@@ -173,6 +191,13 @@ function fileIdentity(details: { dev: bigint | number; ino: bigint | number }) {
 	};
 }
 
+function hasExactKeys(value: object, expected: readonly string[]) {
+	return (
+		JSON.stringify(Object.keys(value).sort()) ===
+		JSON.stringify([...expected].sort())
+	);
+}
+
 function sameIdentity(
 	details: { dev: bigint | number; ino: bigint | number },
 	expected: FileIdentity,
@@ -180,6 +205,18 @@ function sameIdentity(
 	return (
 		details.dev.toString() === expected.device &&
 		details.ino.toString() === expected.inode
+	);
+}
+
+function validFileIdentity(value: unknown): value is FileIdentity {
+	return (
+		!!value &&
+		typeof value === "object" &&
+		typeof (value as { device?: unknown }).device === "string" &&
+		/^\d{1,40}$/.test((value as { device: string }).device) &&
+		typeof (value as { inode?: unknown }).inode === "string" &&
+		/^[1-9]\d{0,39}$/.test((value as { inode: string }).inode) &&
+		hasExactKeys(value, ["device", "inode"])
 	);
 }
 
@@ -852,6 +889,45 @@ function validateTransactionNonce(nonce: string) {
 	return nonce;
 }
 
+function stagingOwnerMarkerBytes(nonce: string) {
+	return Buffer.from(`openapi-to-staging:${nonce}\n`, "utf8");
+}
+
+async function createStagingOwnership(
+	lockPath: string,
+	stagingRoot: string,
+	nonce: string,
+): Promise<StagingOwnershipRecord> {
+	const details = await lstat(stagingRoot, { bigint: true });
+	if (
+		details.isSymbolicLink() ||
+		!details.isDirectory() ||
+		details.ino === 0n
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership could not be established safely.",
+		);
+	}
+	await writeFile(
+		path.join(stagingRoot, stagingOwnerMarkerName),
+		stagingOwnerMarkerBytes(nonce),
+		{ flag: "wx", mode: 0o600 },
+	);
+	const record: StagingOwnershipRecord = {
+		schemaVersion: 1,
+		nonce,
+		stagingDirectory: path.basename(stagingRoot),
+		stagingIdentity: fileIdentity(details),
+	};
+	await writeExclusiveRecordAtomically(
+		path.join(lockPath, stagingOwnerRecordName),
+		`${stagingOwnerRecordName}.tmp-${nonce}`,
+		record,
+	);
+	return record;
+}
+
 function validateInstallJournal(
 	value: unknown,
 	expectedPackageVersion: string,
@@ -859,13 +935,24 @@ function validateInstallJournal(
 	if (
 		!value ||
 		typeof value !== "object" ||
-		(value as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+		(value as { schemaVersion?: unknown }).schemaVersion !== 2 ||
 		(value as { packageVersion?: unknown }).packageVersion !==
 			expectedPackageVersion ||
 		!Number.isSafeInteger((value as { pid?: unknown }).pid) ||
 		((value as { pid: number }).pid ?? 0) <= 0 ||
 		typeof (value as { nonce?: unknown }).nonce !== "string" ||
-		!Array.isArray((value as { skills?: unknown }).skills)
+		!Array.isArray((value as { skills?: unknown }).skills) ||
+		!hasExactKeys(value, [
+			"schemaVersion",
+			"packageVersion",
+			"pid",
+			"nonce",
+			"stagingDirectory",
+			"stagingOwnerRecord",
+			"stagingOwnerMarker",
+			"stagingQuarantine",
+			"skills",
+		])
 	) {
 		return fail(
 			"SKILLS_INSTALL_RECOVERY_REQUIRED",
@@ -876,6 +963,9 @@ function validateInstallJournal(
 	if (
 		!/^[a-zA-Z0-9-]{1,128}$/.test(journal.nonce) ||
 		journal.stagingDirectory !== `${stagingDirectoryPrefix}${journal.nonce}` ||
+		journal.stagingOwnerRecord !== stagingOwnerRecordName ||
+		journal.stagingOwnerMarker !== stagingOwnerMarkerName ||
+		journal.stagingQuarantine !== stagingQuarantineName ||
 		JSON.stringify(journal.skills) !== JSON.stringify(supportedSkillNames)
 	) {
 		return fail(
@@ -886,15 +976,59 @@ function validateInstallJournal(
 	return journal;
 }
 
+function validateStagingOwnershipRecord(
+	value: unknown,
+	journal: InstallJournal,
+): StagingOwnershipRecord {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		(value as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+		(value as { nonce?: unknown }).nonce !== journal.nonce ||
+		(value as { stagingDirectory?: unknown }).stagingDirectory !==
+			journal.stagingDirectory ||
+		!validFileIdentity(
+			(value as { stagingIdentity?: unknown }).stagingIdentity,
+		) ||
+		!hasExactKeys(value, [
+			"schemaVersion",
+			"nonce",
+			"stagingDirectory",
+			"stagingIdentity",
+		])
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership evidence requires manual inspection.",
+		);
+	}
+	return value as StagingOwnershipRecord;
+}
+
 async function writeInstallJournal(
 	lockPath: string,
 	journal: InstallJournal,
 ): Promise<void> {
-	await writeFile(
+	await writeExclusiveRecordAtomically(
 		path.join(lockPath, installJournalName),
-		`${JSON.stringify(journal, null, 2)}\n`,
+		`${installJournalName}.tmp-${journal.nonce}`,
+		journal,
+	);
+}
+
+async function writeExclusiveRecordAtomically(
+	destination: string,
+	temporaryName: string,
+	value: object,
+): Promise<void> {
+	const temporaryPath = path.join(path.dirname(destination), temporaryName);
+	await writeFile(
+		temporaryPath,
+		`${JSON.stringify(value, null, 2)}\n`,
 		{ flag: "wx", mode: 0o600 },
 	);
+	await link(temporaryPath, destination);
+	await unlink(temporaryPath);
 }
 
 async function readInstallJournal(
@@ -904,10 +1038,23 @@ async function readInstallJournal(
 	try {
 		const entries = await readdir(lockPath, { withFileTypes: true });
 		if (
-			entries.length !== 1 ||
-			entries[0]?.name !== installJournalName ||
-			!entries[0].isFile() ||
-			entries[0].isSymbolicLink()
+			entries.length < 1 ||
+			entries.length > 3 ||
+			!entries.some((entry) => entry.name === installJournalName) ||
+			entries.some(
+				(entry) => {
+					if (entry.isSymbolicLink()) return true;
+					if (
+						[installJournalName, stagingOwnerRecordName].includes(entry.name)
+					) {
+						return !entry.isFile();
+					}
+					if (entry.name === stagingQuarantineName) {
+						return !entry.isDirectory();
+					}
+					return true;
+				},
+			)
 		) {
 			return fail(
 				"SKILLS_INSTALL_RECOVERY_REQUIRED",
@@ -940,6 +1087,38 @@ async function readInstallJournal(
 	}
 }
 
+async function readStagingOwnershipRecord(
+	lockPath: string,
+	journal: InstallJournal,
+): Promise<StagingOwnershipRecord | undefined> {
+	try {
+		const recordPath = path.join(lockPath, journal.stagingOwnerRecord);
+		const details = await lstatIfPresent(recordPath);
+		if (!details) return undefined;
+		if (
+			details.isSymbolicLink() ||
+			!details.isFile() ||
+			details.size <= 0 ||
+			details.size > stagingOwnerRecordByteLimit
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership evidence requires manual inspection.",
+			);
+		}
+		return validateStagingOwnershipRecord(
+			JSON.parse(await readFile(recordPath, "utf8")),
+			journal,
+		);
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership evidence requires manual inspection.",
+		);
+	}
+}
+
 function processIsActive(pid: number, nonce: string) {
 	if (pid === process.pid) return activeTransactionNonces.has(nonce);
 	try {
@@ -950,34 +1129,344 @@ function processIsActive(pid: number, nonce: string) {
 	}
 }
 
-async function assertOwnedDirectory(target: string, message: string) {
-	const details = await lstatIfPresent(target);
-	if (!details) return false;
-	if (details.isSymbolicLink() || !details.isDirectory()) {
-		return fail("SKILLS_INSTALL_RECOVERY_REQUIRED", message);
+async function verifyOwnedStagingDirectory(
+	skillsRoot: string,
+	lockPath: string,
+	candidateRoot: string,
+	journal: InstallJournal,
+	ownership: StagingOwnershipRecord,
+	skills: VerifiedSkill[],
+) {
+	try {
+		const expectedStagingRoot = path.join(
+			skillsRoot,
+			journal.stagingDirectory,
+		);
+		const expectedQuarantineRoot = path.join(
+			lockPath,
+			journal.stagingQuarantine,
+		);
+		if (
+			(candidateRoot !== expectedStagingRoot &&
+				candidateRoot !== expectedQuarantineRoot) ||
+			ownership.nonce !== journal.nonce ||
+			ownership.stagingDirectory !== journal.stagingDirectory
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership could not be proven.",
+			);
+		}
+		const details = await lstat(candidateRoot, { bigint: true });
+		if (
+			details.isSymbolicLink() ||
+			!details.isDirectory() ||
+			!sameIdentity(details, ownership.stagingIdentity)
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership could not be proven.",
+			);
+		}
+		const markerPath = path.join(candidateRoot, journal.stagingOwnerMarker);
+		const markerDetails = await lstat(markerPath);
+		const expectedMarker = stagingOwnerMarkerBytes(journal.nonce);
+		if (
+			markerDetails.isSymbolicLink() ||
+			!markerDetails.isFile() ||
+			markerDetails.size !== expectedMarker.byteLength ||
+			!(await readFile(markerPath)).equals(expectedMarker)
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership marker could not be proven.",
+			);
+		}
+		const tree = await listSkillTree(candidateRoot);
+		const expectedDirectories = new Set<string>();
+		const expectedFiles = new Map<string, VerifiedSkillFile>();
+		for (const skill of skills) {
+			expectedDirectories.add(skill.name);
+			for (const directory of expectedSkillDirectories(skill)) {
+				expectedDirectories.add(`${skill.name}/${directory}`);
+			}
+			for (const file of skill.files) {
+				expectedFiles.set(`${skill.name}/${file.path}`, file);
+			}
+		}
+		if (
+			tree.directories.some(
+				(directory) => !expectedDirectories.has(directory),
+			) ||
+			tree.files.some(
+				(file) =>
+					file !== journal.stagingOwnerMarker && !expectedFiles.has(file),
+			)
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging contains unexplained entries.",
+			);
+		}
+		for (const relativePath of tree.files) {
+			if (relativePath === journal.stagingOwnerMarker) continue;
+			const expected = expectedFiles.get(relativePath);
+			if (!expected) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill staging contains unexplained entries.",
+				);
+			}
+			const bytes = await readFile(
+				path.join(candidateRoot, ...relativePath.split("/")),
+			);
+			if (
+				bytes.byteLength !== expected.size ||
+				createHash("sha256").update(bytes).digest("hex") !== expected.sha256
+			) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill staging contains changed bytes.",
+				);
+			}
+		}
+		const finalDetails = await lstat(candidateRoot, { bigint: true });
+		if (
+			finalDetails.isSymbolicLink() ||
+			!finalDetails.isDirectory() ||
+			!sameIdentity(finalDetails, ownership.stagingIdentity)
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership changed during verification.",
+			);
+		}
+	} catch (error) {
+		if (
+			error instanceof SkillsInstallError &&
+			error.code === "SKILLS_INSTALL_RECOVERY_REQUIRED"
+		) {
+			throw error;
+		}
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership could not be proven.",
+		);
 	}
-	return true;
+}
+
+async function assertOwnedStagingRoot(
+	candidateRoot: string,
+	ownership: StagingOwnershipRecord,
+) {
+	try {
+		const details = await lstat(candidateRoot, { bigint: true });
+		if (
+			details.isSymbolicLink() ||
+			!details.isDirectory() ||
+			!sameIdentity(details, ownership.stagingIdentity)
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership changed during cleanup.",
+			);
+		}
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership changed during cleanup.",
+		);
+	}
+}
+
+async function removeVerifiedStagingTree(
+	candidateRoot: string,
+	journal: InstallJournal,
+	ownership: StagingOwnershipRecord,
+	skills: VerifiedSkill[],
+) {
+	try {
+		const expectedFiles = skills
+			.flatMap((skill) =>
+				skill.files.map((file) => `${skill.name}/${file.path}`),
+			)
+			.sort(compareText);
+		for (const relativePath of expectedFiles) {
+			await assertOwnedStagingRoot(candidateRoot, ownership);
+			const target = path.join(
+				candidateRoot,
+				...relativePath.split("/"),
+			);
+			const details = await lstatIfPresent(target);
+			if (!details) continue;
+			if (details.isSymbolicLink() || !details.isFile()) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill staging entries changed during cleanup.",
+				);
+			}
+			await unlink(target);
+		}
+		const expectedDirectories = skills
+			.flatMap((skill) => [
+				skill.name,
+				...[...expectedSkillDirectories(skill)].map(
+					(directory) => `${skill.name}/${directory}`,
+				),
+			])
+			.sort((left, right) => {
+				const depthDifference =
+					right.split("/").length - left.split("/").length;
+				return depthDifference || compareText(right, left);
+			});
+		for (const relativePath of expectedDirectories) {
+			await assertOwnedStagingRoot(candidateRoot, ownership);
+			const target = path.join(
+				candidateRoot,
+				...relativePath.split("/"),
+			);
+			const details = await lstatIfPresent(target);
+			if (!details) continue;
+			if (details.isSymbolicLink() || !details.isDirectory()) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill staging entries changed during cleanup.",
+				);
+			}
+			await rmdir(target);
+		}
+		await assertOwnedStagingRoot(candidateRoot, ownership);
+		const markerPath = path.join(candidateRoot, journal.stagingOwnerMarker);
+		const markerDetails = await lstatIfPresent(markerPath);
+		if (markerDetails) {
+			if (markerDetails.isSymbolicLink() || !markerDetails.isFile()) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill staging ownership marker changed during cleanup.",
+				);
+			}
+			await unlink(markerPath);
+		}
+		await assertOwnedStagingRoot(candidateRoot, ownership);
+		await rmdir(candidateRoot);
+	} catch (error) {
+		if (
+			error instanceof SkillsInstallError &&
+			error.code === "SKILLS_INSTALL_RECOVERY_REQUIRED"
+		) {
+			throw error;
+		}
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging cleanup requires manual inspection.",
+		);
+	}
+}
+
+async function removeOwnedStagingDirectory(
+	codexHome: string,
+	skillsRoot: string,
+	lockPath: string,
+	stagingRoot: string,
+	identity: DestinationIdentity,
+	journal: InstallJournal,
+	ownership: StagingOwnershipRecord | undefined,
+	skills: VerifiedSkill[],
+	beforeStagingDetach?: SkillsInstallDependencies["beforeStagingDetach"],
+	beforeQuarantineCleanup?: SkillsInstallDependencies["beforeQuarantineCleanup"],
+) {
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+	const stagingDetails = await lstatIfPresent(stagingRoot);
+	const quarantineRoot = path.join(lockPath, journal.stagingQuarantine);
+	const quarantineDetails = await lstatIfPresent(quarantineRoot);
+	if (stagingDetails && quarantineDetails) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging cleanup contains ambiguous paths.",
+		);
+	}
+	if (!stagingDetails && !quarantineDetails) return;
+	if (!ownership) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging ownership evidence is missing.",
+		);
+	}
+	if (stagingDetails) {
+		await verifyOwnedStagingDirectory(
+			skillsRoot,
+			lockPath,
+			stagingRoot,
+			journal,
+			ownership,
+			skills,
+		);
+		await beforeStagingDetach?.();
+		await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+		try {
+			await rename(stagingRoot, quarantineRoot);
+		} catch {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging could not be detached safely.",
+			);
+		}
+	}
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+	await verifyOwnedStagingDirectory(
+		skillsRoot,
+		lockPath,
+		quarantineRoot,
+		journal,
+		ownership,
+		skills,
+	);
+	await beforeQuarantineCleanup?.();
+	await removeVerifiedStagingTree(
+		quarantineRoot,
+		journal,
+		ownership,
+		skills,
+	);
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 }
 
 async function cleanupTransaction(
+	codexHome: string,
+	skillsRoot: string,
 	lockPath: string,
 	stagingRoot: string,
-	stagingCreated: boolean,
+	identity: DestinationIdentity,
+	journal: InstallJournal,
+	skills: VerifiedSkill[],
+	beforeStagingDetach?: SkillsInstallDependencies["beforeStagingDetach"],
+	beforeQuarantineCleanup?: SkillsInstallDependencies["beforeQuarantineCleanup"],
 ) {
-	if (
-		stagingCreated &&
-		(await assertOwnedDirectory(
-			stagingRoot,
-			"An interrupted Codex Skill staging path requires manual inspection.",
-		))
-	) {
-		await rm(stagingRoot, { recursive: true, force: false });
+	const ownership = await readStagingOwnershipRecord(lockPath, journal);
+	await removeOwnedStagingDirectory(
+		codexHome,
+		skillsRoot,
+		lockPath,
+		stagingRoot,
+		identity,
+		journal,
+		ownership,
+		skills,
+		beforeStagingDetach,
+		beforeQuarantineCleanup,
+	);
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+	if (ownership) {
+		await unlink(path.join(lockPath, journal.stagingOwnerRecord));
+		await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 	}
 	await unlink(path.join(lockPath, installJournalName)).catch(
 		(error: NodeJS.ErrnoException) => {
 			if (error.code !== "ENOENT") throw error;
 		},
 	);
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 	await rmdir(lockPath);
 }
 
@@ -986,6 +1475,8 @@ async function recoverInterruptedInstallation(
 	skillsRoot: string,
 	packageVersion: string,
 	skills: VerifiedSkill[],
+	beforeStagingDetach?: SkillsInstallDependencies["beforeStagingDetach"],
+	beforeQuarantineCleanup?: SkillsInstallDependencies["beforeQuarantineCleanup"],
 ) {
 	const lockPath = path.join(skillsRoot, installLockName);
 	const lockDetails = await lstatIfPresent(lockPath);
@@ -1021,10 +1512,58 @@ async function recoverInterruptedInstallation(
 		lockPath,
 	);
 	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
-	const stagingPresent = await assertOwnedDirectory(
-		stagingRoot,
-		"An interrupted Codex Skill staging path requires manual inspection.",
-	);
+	const ownership = await readStagingOwnershipRecord(lockPath, journal);
+	const stagingDetails = await lstatIfPresent(stagingRoot);
+	const quarantineRoot = path.join(lockPath, journal.stagingQuarantine);
+	const quarantineDetails = await lstatIfPresent(quarantineRoot);
+	if (stagingDetails && quarantineDetails) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"Codex Skill staging cleanup contains ambiguous paths.",
+		);
+	}
+	const ownedStagingRoot = stagingDetails
+		? stagingRoot
+		: quarantineDetails
+			? quarantineRoot
+			: undefined;
+	if (ownedStagingRoot) {
+		if (!ownership) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"Codex Skill staging ownership evidence is missing.",
+			);
+		}
+		await verifyOwnedStagingDirectory(
+			skillsRoot,
+			lockPath,
+			ownedStagingRoot,
+			journal,
+			ownership,
+			skills,
+		);
+	} else if (!ownership) {
+		for (const skill of skills) {
+			if (await lstatIfPresent(path.join(skillsRoot, skill.name))) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"An interrupted Codex Skill installation requires manual inspection.",
+				);
+			}
+		}
+		await cleanupTransaction(
+			codexHome,
+			skillsRoot,
+			lockPath,
+			stagingRoot,
+			identity,
+			journal,
+			skills,
+			beforeStagingDetach,
+			beforeQuarantineCleanup,
+		);
+		return false;
+	}
 	const ownedTargets: OwnedSkillTarget[] = [];
 	for (const skill of skills) {
 		const destination = path.join(skillsRoot, skill.name);
@@ -1083,7 +1622,17 @@ async function recoverInterruptedInstallation(
 		}
 	}
 	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
-	await cleanupTransaction(lockPath, stagingRoot, stagingPresent);
+	await cleanupTransaction(
+		codexHome,
+		skillsRoot,
+		lockPath,
+		stagingRoot,
+		identity,
+		journal,
+		skills,
+		beforeStagingDetach,
+		beforeQuarantineCleanup,
+	);
 	return installationComplete;
 }
 
@@ -1231,6 +1780,8 @@ export async function installCodexSkills(
 				skillsRoot,
 				packageVersion,
 				verifiedSkills,
+				dependencies.beforeStagingDetach,
+				dependencies.beforeQuarantineCleanup,
 			));
 		const output: SkillsInstallOutput = {
 			success: true,
@@ -1255,9 +1806,9 @@ export async function installCodexSkills(
 
 		let lockAcquired = false;
 		let journalWritten = false;
-		let stagingCreated = false;
 		let preserveTransaction = false;
 		let identity: DestinationIdentity | undefined;
+		let journal: InstallJournal | undefined;
 		let installed = false;
 		const nonce = validateTransactionNonce(
 			(dependencies.transactionNonce ?? randomUUID)(),
@@ -1297,14 +1848,18 @@ export async function installCodexSkills(
 				lockPath,
 			);
 			activeTransactionNonces.add(nonce);
-			await writeInstallJournal(lockPath, {
-				schemaVersion: 1,
+			journal = {
+				schemaVersion: 2,
 				packageVersion,
 				pid: dependencies.processId ?? process.pid,
 				nonce,
 				stagingDirectory: path.basename(stagingRoot),
+				stagingOwnerRecord: stagingOwnerRecordName,
+				stagingOwnerMarker: stagingOwnerMarkerName,
+				stagingQuarantine: stagingQuarantineName,
 				skills: [...supportedSkillNames],
-			});
+			};
+			await writeInstallJournal(lockPath, journal);
 			journalWritten = true;
 			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 			const lockedState = await preflightDestination(codexHome, skillsRoot, {
@@ -1319,7 +1874,7 @@ export async function installCodexSkills(
 			await dependencies.beforeStaging?.();
 			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 			await mkdir(stagingRoot, { mode: 0o700 });
-			stagingCreated = true;
+			await createStagingOwnership(lockPath, stagingRoot, nonce);
 			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
 			const fileWriter = dependencies.writeFile ?? writeFile;
 			await writeStagedSkills(stagingRoot, verifiedSkills, fileWriter);
@@ -1362,9 +1917,25 @@ export async function installCodexSkills(
 			const cleanupSafe =
 				!identity ||
 				(await destinationIsStable(codexHome, skillsRoot, lockPath, identity));
+			if (lockAcquired && !preserveTransaction && !cleanupSafe) {
+				fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"Codex Skill installation cleanup requires manual inspection.",
+				);
+			}
 			if (lockAcquired && !preserveTransaction && cleanupSafe) {
-				if (journalWritten) {
-					await cleanupTransaction(lockPath, stagingRoot, stagingCreated);
+				if (journalWritten && journal && identity) {
+					await cleanupTransaction(
+						codexHome,
+						skillsRoot,
+						lockPath,
+						stagingRoot,
+						identity,
+						journal,
+						verifiedSkills,
+						dependencies.beforeStagingDetach,
+						dependencies.beforeQuarantineCleanup,
+					);
 				} else {
 					await rmdir(lockPath);
 				}

--- a/packages/cli/src/skillsInstall.ts
+++ b/packages/cli/src/skillsInstall.ts
@@ -1,0 +1,1420 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import {
+	access,
+	lstat,
+	mkdir,
+	readdir,
+	readFile,
+	rm,
+	rmdir,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
+
+const supportedSkillNames = [
+	"openapi-to-generate",
+	"openapi-to-setup",
+] as const;
+const manifestByteLimit = 1024 * 1024;
+const skillFileByteLimit = 16 * 1024 * 1024;
+const distributionByteLimit = 64 * 1024 * 1024;
+const installLockName = ".openapi-to-skills-install.lock";
+const installJournalName = "transaction.json";
+const stagingDirectoryPrefix = ".openapi-to-skills-install-";
+const installJournalByteLimit = 16 * 1024;
+const targetOwnerMarkerName = ".openapi-to-install-owner";
+const activeTransactionNonces = new Set<string>();
+
+type SupportedSkillName = (typeof supportedSkillNames)[number];
+
+interface SkillFileManifest {
+	path: string;
+	size: number;
+	sha256: string;
+}
+
+interface SkillManifest {
+	name: SupportedSkillName;
+	files: SkillFileManifest[];
+}
+
+interface DistributionManifest {
+	schemaVersion: 1;
+	packageVersion: string;
+	skills: SkillManifest[];
+}
+
+interface VerifiedSkillFile extends SkillFileManifest {
+	bytes: Buffer;
+}
+
+interface VerifiedSkill {
+	name: SupportedSkillName;
+	files: VerifiedSkillFile[];
+}
+
+interface InstallJournal {
+	schemaVersion: 1;
+	packageVersion: string;
+	pid: number;
+	nonce: string;
+	stagingDirectory: string;
+	skills: SupportedSkillName[];
+}
+
+interface FileIdentity {
+	device: string;
+	inode: string;
+}
+
+interface DestinationIdentity {
+	codexHome: FileIdentity;
+	skillsRoot: FileIdentity;
+	lock: FileIdentity;
+}
+
+interface OwnedSkillTarget {
+	skill: VerifiedSkill;
+	identity: FileIdentity;
+	markerPresent: boolean;
+}
+
+export interface SkillsInstallRequest {
+	dryRun: boolean;
+	json: boolean;
+}
+
+export interface SkillsInstallDependencies {
+	assetRoot?: string;
+	environment?: NodeJS.ProcessEnv;
+	homeDirectory?: () => string;
+	beforeStaging?: () => Promise<void>;
+	beforeTargetCommit?: (
+		skill: SupportedSkillName,
+		index: number,
+	) => Promise<void>;
+	afterTargetCommit?: (
+		skill: SupportedSkillName,
+		index: number,
+	) => Promise<void>;
+	beforeTargetRollback?: (skill: SupportedSkillName) => Promise<void>;
+	processId?: number;
+	remove?: typeof rm;
+	transactionNonce?: () => string;
+	writeFile?: typeof writeFile;
+}
+
+export interface SkillsInstallOutput {
+	success: true;
+	command: "skills install";
+	mode: "dry-run" | "install";
+	host: "codex";
+	packageVersion: string;
+	source: "packaged-npm-assets";
+	destinationRoot: string;
+	skills: SupportedSkillName[];
+	actions: Array<{
+		action: "install";
+		skill: SupportedSkillName;
+		destination: string;
+	}>;
+	installed: SupportedSkillName[];
+	restartRequired: true;
+}
+
+export class SkillsInstallError extends Error {
+	readonly code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "SkillsInstallError";
+		this.code = code;
+	}
+}
+
+function compareText(left: string, right: string): number {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function safeRelativePath(relativePath: unknown): relativePath is string {
+	return (
+		typeof relativePath === "string" &&
+		relativePath.length > 0 &&
+		!relativePath.includes("\\") &&
+		!relativePath.includes("\0") &&
+		!path.posix.isAbsolute(relativePath) &&
+		path.posix.normalize(relativePath) === relativePath &&
+		relativePath !== "." &&
+		!relativePath.startsWith("../") &&
+		relativePath.split("/").every((segment) => segment.length > 0)
+	);
+}
+
+function fail(code: string, message: string): never {
+	throw new SkillsInstallError(code, message);
+}
+
+async function lstatIfPresent(target: string) {
+	try {
+		return await lstat(target);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+		throw error;
+	}
+}
+
+function fileIdentity(details: { dev: bigint | number; ino: bigint | number }) {
+	return {
+		device: details.dev.toString(),
+		inode: details.ino.toString(),
+	};
+}
+
+function sameIdentity(
+	details: { dev: bigint | number; ino: bigint | number },
+	expected: FileIdentity,
+) {
+	return (
+		details.dev.toString() === expected.device &&
+		details.ino.toString() === expected.inode
+	);
+}
+
+async function captureDestinationIdentity(
+	codexHome: string,
+	skillsRoot: string,
+	lockPath: string,
+): Promise<DestinationIdentity> {
+	try {
+		const [home, root, lock] = await Promise.all([
+			lstat(codexHome, { bigint: true }),
+			lstat(skillsRoot, { bigint: true }),
+			lstat(lockPath, { bigint: true }),
+		]);
+		if (
+			home.isSymbolicLink() ||
+			!home.isDirectory() ||
+			root.isSymbolicLink() ||
+			!root.isDirectory() ||
+			lock.isSymbolicLink() ||
+			!lock.isDirectory()
+		) {
+			return fail(
+				"SKILLS_DESTINATION_CHANGED",
+				"The Codex Skill destination changed during installation and requires manual inspection.",
+			);
+		}
+		return {
+			codexHome: fileIdentity(home),
+			skillsRoot: fileIdentity(root),
+			lock: fileIdentity(lock),
+		};
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			"SKILLS_DESTINATION_CHANGED",
+			"The Codex Skill destination changed during installation and requires manual inspection.",
+		);
+	}
+}
+
+async function assertDestinationStable(
+	codexHome: string,
+	skillsRoot: string,
+	lockPath: string,
+	expected: DestinationIdentity,
+) {
+	try {
+		const [home, root, lock] = await Promise.all([
+			lstat(codexHome, { bigint: true }),
+			lstat(skillsRoot, { bigint: true }),
+			lstat(lockPath, { bigint: true }),
+		]);
+		if (
+			home.isSymbolicLink() ||
+			!home.isDirectory() ||
+			!sameIdentity(home, expected.codexHome) ||
+			root.isSymbolicLink() ||
+			!root.isDirectory() ||
+			!sameIdentity(root, expected.skillsRoot) ||
+			lock.isSymbolicLink() ||
+			!lock.isDirectory() ||
+			!sameIdentity(lock, expected.lock)
+		) {
+			return fail(
+				"SKILLS_DESTINATION_CHANGED",
+				"The Codex Skill destination changed during installation and requires manual inspection.",
+			);
+		}
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			"SKILLS_DESTINATION_CHANGED",
+			"The Codex Skill destination changed during installation and requires manual inspection.",
+		);
+	}
+}
+
+async function destinationIsStable(
+	codexHome: string,
+	skillsRoot: string,
+	lockPath: string,
+	expected: DestinationIdentity,
+) {
+	try {
+		await assertDestinationStable(codexHome, skillsRoot, lockPath, expected);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function validateManifest(
+	value: unknown,
+	expectedPackageVersion: string,
+): DistributionManifest {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		(value as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+		(value as { packageVersion?: unknown }).packageVersion !==
+			expectedPackageVersion ||
+		!Array.isArray((value as { skills?: unknown }).skills)
+	) {
+		return fail(
+			"SKILLS_MANIFEST_INVALID",
+			"The packaged Skill manifest is missing, malformed, or does not match this package version.",
+		);
+	}
+	const skills = (value as { skills: unknown[] }).skills;
+	if (
+		skills.length !== supportedSkillNames.length ||
+		skills.some(
+			(skill, index) =>
+				!skill ||
+				typeof skill !== "object" ||
+				(skill as { name?: unknown }).name !== supportedSkillNames[index] ||
+				!Array.isArray((skill as { files?: unknown }).files),
+		)
+	) {
+		return fail(
+			"SKILLS_MANIFEST_INVALID",
+			"The packaged Skill manifest must contain exactly the supported Codex Skills in stable order.",
+		);
+	}
+	for (const skill of skills as SkillManifest[]) {
+		const paths = new Set<string>();
+		if (skill.files.length === 0) {
+			return fail(
+				"SKILLS_MANIFEST_INVALID",
+				`The packaged Skill manifest contains no files for ${skill.name}.`,
+			);
+		}
+		for (const file of skill.files) {
+			if (
+				!file ||
+				typeof file !== "object" ||
+				!safeRelativePath(file.path) ||
+				!Number.isSafeInteger(file.size) ||
+				file.size <= 0 ||
+				file.size > skillFileByteLimit ||
+				typeof file.sha256 !== "string" ||
+				!/^[a-f0-9]{64}$/.test(file.sha256) ||
+				paths.has(file.path)
+			) {
+				return fail(
+					"SKILLS_MANIFEST_INVALID",
+					`The packaged Skill manifest contains an invalid file record for ${skill.name}.`,
+				);
+			}
+			paths.add(file.path);
+		}
+		if (!paths.has("SKILL.md")) {
+			return fail(
+				"SKILLS_MANIFEST_INVALID",
+				`The packaged Skill manifest is missing ${skill.name}/SKILL.md.`,
+			);
+		}
+	}
+	return value as DistributionManifest;
+}
+
+async function listSkillTree(
+	root: string,
+	relativeDirectory = "",
+): Promise<{ directories: string[]; files: string[] }> {
+	const directory = path.join(
+		root,
+		...relativeDirectory.split("/").filter(Boolean),
+	);
+	const entries = (await readdir(directory, { withFileTypes: true })).sort(
+		(left, right) => compareText(left.name, right.name),
+	);
+	const tree = { directories: [] as string[], files: [] as string[] };
+	for (const entry of entries) {
+		const relativePath = relativeDirectory
+			? `${relativeDirectory}/${entry.name}`
+			: entry.name;
+		if (!safeRelativePath(relativePath)) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				"The packaged Skill assets contain an unsafe path.",
+			);
+		}
+		const absolutePath = path.join(root, ...relativePath.split("/"));
+		const details = await lstat(absolutePath);
+		if (details.isSymbolicLink()) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				`The packaged Skill assets contain a symlink at ${relativePath}.`,
+			);
+		}
+		if (details.isDirectory()) {
+			tree.directories.push(relativePath);
+			const nested = await listSkillTree(root, relativePath);
+			tree.directories.push(...nested.directories);
+			tree.files.push(...nested.files);
+			continue;
+		}
+		if (!details.isFile()) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				`The packaged Skill assets contain a non-regular file at ${relativePath}.`,
+			);
+		}
+		tree.files.push(relativePath);
+	}
+	return tree;
+}
+
+async function listRegularFiles(
+	root: string,
+	relativeDirectory = "",
+): Promise<string[]> {
+	return (await listSkillTree(root, relativeDirectory)).files;
+}
+
+async function verifyPackagedSkills(
+	assetRoot: string,
+	expectedPackageVersion: string,
+): Promise<VerifiedSkill[]> {
+	const rootDetails = await lstatIfPresent(assetRoot);
+	if (!rootDetails?.isDirectory() || rootDetails.isSymbolicLink()) {
+		return fail(
+			"SKILLS_MANIFEST_INVALID",
+			"The packaged Skill asset directory is missing or invalid.",
+		);
+	}
+	const rootEntries = (await readdir(assetRoot, { withFileTypes: true })).sort(
+		(left, right) => compareText(left.name, right.name),
+	);
+	const expectedRootEntries = ["manifest.json", ...supportedSkillNames].sort(
+		compareText,
+	);
+	if (
+		JSON.stringify(rootEntries.map(({ name }) => name)) !==
+		JSON.stringify(expectedRootEntries)
+	) {
+		return fail(
+			"SKILLS_ASSET_INTEGRITY_FAILED",
+			"The packaged Skill asset directory contains an unexpected file set.",
+		);
+	}
+	for (const entry of rootEntries) {
+		if (entry.isSymbolicLink()) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				"The packaged Skill asset directory contains a symlink.",
+			);
+		}
+		if (
+			(entry.name === "manifest.json" && !entry.isFile()) ||
+			(entry.name !== "manifest.json" && !entry.isDirectory())
+		) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				"The packaged Skill asset directory has an invalid structure.",
+			);
+		}
+	}
+	const manifestPath = path.join(assetRoot, "manifest.json");
+	const manifestDetails = await lstat(manifestPath);
+	if (
+		manifestDetails.isSymbolicLink() ||
+		!manifestDetails.isFile() ||
+		manifestDetails.size > manifestByteLimit
+	) {
+		return fail(
+			"SKILLS_MANIFEST_INVALID",
+			"The packaged Skill manifest is missing or exceeds its safety limit.",
+		);
+	}
+	let parsedManifest: unknown;
+	try {
+		parsedManifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	} catch {
+		return fail(
+			"SKILLS_MANIFEST_INVALID",
+			"The packaged Skill manifest is not valid JSON.",
+		);
+	}
+	const manifest = validateManifest(parsedManifest, expectedPackageVersion);
+	let totalBytes = 0;
+	const verified: VerifiedSkill[] = [];
+	for (const skill of manifest.skills) {
+		const skillRoot = path.join(assetRoot, skill.name);
+		const rootDetails = await lstat(skillRoot);
+		if (rootDetails.isSymbolicLink() || !rootDetails.isDirectory()) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				`The packaged Skill directory is invalid for ${skill.name}.`,
+			);
+		}
+		const actualPaths = await listRegularFiles(skillRoot);
+		const declaredPaths = skill.files.map(({ path }) => path);
+		if (JSON.stringify(actualPaths) !== JSON.stringify(declaredPaths)) {
+			return fail(
+				"SKILLS_ASSET_INTEGRITY_FAILED",
+				`The packaged file set does not match the manifest for ${skill.name}.`,
+			);
+		}
+		const files: VerifiedSkillFile[] = [];
+		for (const file of skill.files) {
+			const absolutePath = path.join(skillRoot, ...file.path.split("/"));
+			const details = await lstat(absolutePath);
+			if (
+				details.isSymbolicLink() ||
+				!details.isFile() ||
+				details.size !== file.size
+			) {
+				return fail(
+					"SKILLS_ASSET_INTEGRITY_FAILED",
+					`The packaged bytes do not match the manifest for ${skill.name}/${file.path}.`,
+				);
+			}
+			totalBytes += details.size;
+			if (totalBytes > distributionByteLimit) {
+				return fail(
+					"SKILLS_ASSET_INTEGRITY_FAILED",
+					"The packaged Skill assets exceed their safety limit.",
+				);
+			}
+			const bytes = await readFile(absolutePath);
+			const sha256 = createHash("sha256").update(bytes).digest("hex");
+			if (sha256 !== file.sha256) {
+				return fail(
+					"SKILLS_ASSET_INTEGRITY_FAILED",
+					`The packaged bytes do not match the manifest for ${skill.name}/${file.path}.`,
+				);
+			}
+			files.push({ ...file, bytes });
+		}
+		verified.push({ name: skill.name, files });
+	}
+	return verified;
+}
+
+function resolveCodexHome(
+	environment: NodeJS.ProcessEnv,
+	homeDirectory: () => string,
+): string {
+	const configured = Object.hasOwn(environment, "CODEX_HOME");
+	const rawCodexHome = configured
+		? environment.CODEX_HOME
+		: path.join(homeDirectory(), ".codex");
+	if (typeof rawCodexHome !== "string" || rawCodexHome.length === 0) {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"CODEX_HOME must be a non-empty absolute path; only the Codex Host is supported.",
+		);
+	}
+	if (!path.isAbsolute(rawCodexHome)) {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"CODEX_HOME must be an absolute path; only the Codex Host is supported.",
+		);
+	}
+	const normalized = path.resolve(rawCodexHome);
+	if (normalized === path.parse(normalized).root) {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"CODEX_HOME must not be a filesystem root.",
+		);
+	}
+	return normalized;
+}
+
+async function preflightDestination(
+	codexHome: string,
+	skillsRoot: string,
+	options: { checkConflicts?: boolean; checkLock?: boolean } = {},
+): Promise<{ codexHomePresent: boolean; skillsRootPresent: boolean }> {
+	let codexHomeDetails: Awaited<ReturnType<typeof lstat>> | undefined;
+	let skillsRootDetails: Awaited<ReturnType<typeof lstat>> | undefined;
+	try {
+		codexHomeDetails = await lstatIfPresent(codexHome);
+		skillsRootDetails = await lstatIfPresent(skillsRoot);
+	} catch {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"The Codex Skill destination cannot be inspected safely.",
+		);
+	}
+	if (
+		codexHomeDetails &&
+		(codexHomeDetails.isSymbolicLink() || !codexHomeDetails.isDirectory())
+	) {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"CODEX_HOME must be a real directory, not a file or symlink.",
+		);
+	}
+	if (
+		skillsRootDetails &&
+		(skillsRootDetails.isSymbolicLink() || !skillsRootDetails.isDirectory())
+	) {
+		return fail(
+			"SKILLS_DESTINATION_INVALID",
+			"The Codex skills root must be a real directory, not a file or symlink.",
+		);
+	}
+	if (skillsRootDetails) {
+		try {
+			await access(skillsRoot, constants.W_OK);
+		} catch {
+			return fail(
+				"SKILLS_DESTINATION_INVALID",
+				"The Codex skills root is not writable.",
+			);
+		}
+	}
+	if (options.checkConflicts !== false) {
+		const conflicts: SupportedSkillName[] = [];
+		for (const name of supportedSkillNames) {
+			try {
+				if (await lstatIfPresent(path.join(skillsRoot, name))) {
+					conflicts.push(name);
+				}
+			} catch {
+				return fail(
+					"SKILLS_DESTINATION_INVALID",
+					"The Codex Skill destinations cannot be inspected safely.",
+				);
+			}
+		}
+		if (conflicts.length > 0) {
+			return fail(
+				"SKILLS_DESTINATION_CONFLICT",
+				`Codex Skill destination already exists for: ${conflicts.join(", ")}. Inspect it manually; this installer never overwrites or merges.`,
+			);
+		}
+	}
+	if (
+		options.checkLock !== false &&
+		(await lstatIfPresent(path.join(skillsRoot, installLockName)))
+	) {
+		return fail(
+			"SKILLS_INSTALL_BUSY",
+			"A Codex Skill installation is already active or requires manual inspection.",
+		);
+	}
+	return {
+		codexHomePresent: codexHomeDetails !== undefined,
+		skillsRootPresent: skillsRootDetails !== undefined,
+	};
+}
+
+async function writeStagedSkills(
+	stagingRoot: string,
+	skills: VerifiedSkill[],
+	write: typeof writeFile,
+) {
+	for (const skill of skills) {
+		for (const file of skill.files) {
+			const destination = path.join(
+				stagingRoot,
+				skill.name,
+				...file.path.split("/"),
+			);
+			await mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+			await write(destination, file.bytes, { flag: "wx", mode: 0o644 });
+		}
+	}
+}
+
+async function verifyInstalledSkill(
+	root: string,
+	skill: VerifiedSkill,
+): Promise<void> {
+	const actualPaths = await listRegularFiles(root);
+	if (
+		JSON.stringify(actualPaths) !==
+		JSON.stringify(skill.files.map(({ path }) => path))
+	) {
+		return fail(
+			"SKILLS_INSTALL_VERIFICATION_FAILED",
+			`Installed file verification failed for ${skill.name}.`,
+		);
+	}
+	for (const file of skill.files) {
+		const bytes = await readFile(path.join(root, ...file.path.split("/")));
+		if (
+			bytes.byteLength !== file.size ||
+			createHash("sha256").update(bytes).digest("hex") !== file.sha256
+		) {
+			return fail(
+				"SKILLS_INSTALL_VERIFICATION_FAILED",
+				`Installed byte verification failed for ${skill.name}/${file.path}.`,
+			);
+		}
+	}
+}
+
+function expectedSkillDirectories(skill: VerifiedSkill) {
+	const directories = new Set<string>();
+	for (const file of skill.files) {
+		const segments = file.path.split("/");
+		for (let index = 1; index < segments.length; index += 1) {
+			directories.add(segments.slice(0, index).join("/"));
+		}
+	}
+	return directories;
+}
+
+async function captureOwnedSkillTarget(
+	root: string,
+	skill: VerifiedSkill,
+	markerPresent: boolean,
+): Promise<OwnedSkillTarget> {
+	const details = await lstat(root, { bigint: true });
+	if (details.isSymbolicLink() || !details.isDirectory()) {
+		return fail(
+			"SKILLS_DESTINATION_CHANGED",
+			`The Codex Skill destination changed during installation for ${skill.name}.`,
+		);
+	}
+	return {
+		skill,
+		identity: fileIdentity(details),
+		markerPresent,
+	};
+}
+
+async function assertOwnedSkillTarget(
+	root: string,
+	target: OwnedSkillTarget,
+	code:
+		| "SKILLS_DESTINATION_CHANGED"
+		| "SKILLS_INSTALL_RECOVERY_REQUIRED" = "SKILLS_DESTINATION_CHANGED",
+) {
+	try {
+		const details = await lstat(root, { bigint: true });
+		if (
+			details.isSymbolicLink() ||
+			!details.isDirectory() ||
+			!sameIdentity(details, target.identity)
+		) {
+			return fail(
+				code,
+				`The Codex Skill destination changed during installation for ${target.skill.name}.`,
+			);
+		}
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			code,
+			`The Codex Skill destination changed during installation for ${target.skill.name}.`,
+		);
+	}
+}
+
+function ownerMarkerBytes(nonce: string) {
+	return Buffer.from(`${nonce}\n`, "utf8");
+}
+
+async function verifyRemovableSkillTarget(
+	root: string,
+	target: OwnedSkillTarget,
+	nonce: string,
+	allowIncompleteWithoutMarker = false,
+) {
+	await assertOwnedSkillTarget(
+		root,
+		target,
+		"SKILLS_INSTALL_RECOVERY_REQUIRED",
+	);
+	const tree = await listSkillTree(root);
+	const expectedDirectories = expectedSkillDirectories(target.skill);
+	if (
+		tree.directories.some((directory) => !expectedDirectories.has(directory))
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			`Codex Skill installation recovery found unexpected directories for ${target.skill.name}.`,
+		);
+	}
+	const expectedFiles = new Map(
+		target.skill.files.map((file) => [file.path, file]),
+	);
+	const markerPath = path.join(root, targetOwnerMarkerName);
+	const markerListed = tree.files.includes(targetOwnerMarkerName);
+	if (target.markerPresent !== markerListed) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			`Codex Skill installation recovery could not prove ownership for ${target.skill.name}.`,
+		);
+	}
+	if (markerListed) {
+		const marker = await readFile(markerPath);
+		if (!marker.equals(ownerMarkerBytes(nonce))) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				`Codex Skill installation recovery found invalid ownership for ${target.skill.name}.`,
+			);
+		}
+	}
+	const actualSkillFiles = tree.files.filter(
+		(file) => file !== targetOwnerMarkerName,
+	);
+	for (const relativePath of actualSkillFiles) {
+		const expected = expectedFiles.get(relativePath);
+		if (!expected) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				`Codex Skill installation recovery found unexpected files for ${target.skill.name}.`,
+			);
+		}
+		const bytes = await readFile(path.join(root, ...relativePath.split("/")));
+		if (
+			bytes.byteLength !== expected.size ||
+			createHash("sha256").update(bytes).digest("hex") !== expected.sha256
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				`Codex Skill installation recovery found changed bytes for ${target.skill.name}.`,
+			);
+		}
+	}
+	if (
+		!markerListed &&
+		!allowIncompleteWithoutMarker &&
+		actualSkillFiles.length !== target.skill.files.length
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			`Codex Skill installation recovery could not prove a complete target for ${target.skill.name}.`,
+		);
+	}
+	await assertOwnedSkillTarget(
+		root,
+		target,
+		"SKILLS_INSTALL_RECOVERY_REQUIRED",
+	);
+}
+
+async function materializeReservedSkill(
+	root: string,
+	target: OwnedSkillTarget,
+	nonce: string,
+	write: typeof writeFile,
+) {
+	await write(path.join(root, targetOwnerMarkerName), ownerMarkerBytes(nonce), {
+		flag: "wx",
+		mode: 0o600,
+	});
+	target.markerPresent = true;
+	await assertOwnedSkillTarget(root, target);
+	await verifyRemovableSkillTarget(root, target, nonce, true);
+	for (const file of target.skill.files) {
+		const destination = path.join(root, ...file.path.split("/"));
+		await mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+		await verifyRemovableSkillTarget(root, target, nonce, true);
+		await write(destination, file.bytes, { flag: "wx", mode: 0o644 });
+		await verifyRemovableSkillTarget(root, target, nonce, true);
+	}
+	await unlink(path.join(root, targetOwnerMarkerName));
+	target.markerPresent = false;
+	await assertOwnedSkillTarget(root, target);
+	await verifyInstalledSkill(root, target.skill);
+	await assertOwnedSkillTarget(root, target);
+}
+
+function validateTransactionNonce(nonce: string) {
+	if (!/^[a-zA-Z0-9-]{1,128}$/.test(nonce)) {
+		return fail(
+			"SKILLS_INSTALL_FAILED",
+			"Codex Skill installation could not create a safe transaction identifier.",
+		);
+	}
+	return nonce;
+}
+
+function validateInstallJournal(
+	value: unknown,
+	expectedPackageVersion: string,
+): InstallJournal {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		(value as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+		(value as { packageVersion?: unknown }).packageVersion !==
+			expectedPackageVersion ||
+		!Number.isSafeInteger((value as { pid?: unknown }).pid) ||
+		((value as { pid: number }).pid ?? 0) <= 0 ||
+		typeof (value as { nonce?: unknown }).nonce !== "string" ||
+		!Array.isArray((value as { skills?: unknown }).skills)
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"An interrupted Codex Skill installation requires manual inspection.",
+		);
+	}
+	const journal = value as InstallJournal;
+	if (
+		!/^[a-zA-Z0-9-]{1,128}$/.test(journal.nonce) ||
+		journal.stagingDirectory !== `${stagingDirectoryPrefix}${journal.nonce}` ||
+		JSON.stringify(journal.skills) !== JSON.stringify(supportedSkillNames)
+	) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"An interrupted Codex Skill installation requires manual inspection.",
+		);
+	}
+	return journal;
+}
+
+async function writeInstallJournal(
+	lockPath: string,
+	journal: InstallJournal,
+): Promise<void> {
+	await writeFile(
+		path.join(lockPath, installJournalName),
+		`${JSON.stringify(journal, null, 2)}\n`,
+		{ flag: "wx", mode: 0o600 },
+	);
+}
+
+async function readInstallJournal(
+	lockPath: string,
+	expectedPackageVersion: string,
+): Promise<InstallJournal> {
+	try {
+		const entries = await readdir(lockPath, { withFileTypes: true });
+		if (
+			entries.length !== 1 ||
+			entries[0]?.name !== installJournalName ||
+			!entries[0].isFile() ||
+			entries[0].isSymbolicLink()
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"An interrupted Codex Skill installation requires manual inspection.",
+			);
+		}
+		const journalPath = path.join(lockPath, installJournalName);
+		const details = await lstat(journalPath);
+		if (
+			details.isSymbolicLink() ||
+			!details.isFile() ||
+			details.size <= 0 ||
+			details.size > installJournalByteLimit
+		) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				"An interrupted Codex Skill installation requires manual inspection.",
+			);
+		}
+		return validateInstallJournal(
+			JSON.parse(await readFile(journalPath, "utf8")),
+			expectedPackageVersion,
+		);
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"An interrupted Codex Skill installation requires manual inspection.",
+		);
+	}
+}
+
+function processIsActive(pid: number, nonce: string) {
+	if (pid === process.pid) return activeTransactionNonces.has(nonce);
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		return (error as NodeJS.ErrnoException).code !== "ESRCH";
+	}
+}
+
+async function assertOwnedDirectory(target: string, message: string) {
+	const details = await lstatIfPresent(target);
+	if (!details) return false;
+	if (details.isSymbolicLink() || !details.isDirectory()) {
+		return fail("SKILLS_INSTALL_RECOVERY_REQUIRED", message);
+	}
+	return true;
+}
+
+async function cleanupTransaction(
+	lockPath: string,
+	stagingRoot: string,
+	stagingCreated: boolean,
+) {
+	if (
+		stagingCreated &&
+		(await assertOwnedDirectory(
+			stagingRoot,
+			"An interrupted Codex Skill staging path requires manual inspection.",
+		))
+	) {
+		await rm(stagingRoot, { recursive: true, force: false });
+	}
+	await unlink(path.join(lockPath, installJournalName)).catch(
+		(error: NodeJS.ErrnoException) => {
+			if (error.code !== "ENOENT") throw error;
+		},
+	);
+	await rmdir(lockPath);
+}
+
+async function recoverInterruptedInstallation(
+	codexHome: string,
+	skillsRoot: string,
+	packageVersion: string,
+	skills: VerifiedSkill[],
+) {
+	const lockPath = path.join(skillsRoot, installLockName);
+	const lockDetails = await lstatIfPresent(lockPath);
+	if (!lockDetails) return false;
+	if (lockDetails.isSymbolicLink() || !lockDetails.isDirectory()) {
+		return fail(
+			"SKILLS_INSTALL_RECOVERY_REQUIRED",
+			"An interrupted Codex Skill installation requires manual inspection.",
+		);
+	}
+	const initialLockEntries = await readdir(lockPath);
+	if (initialLockEntries.length === 0) {
+		const identity = await captureDestinationIdentity(
+			codexHome,
+			skillsRoot,
+			lockPath,
+		);
+		await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+		await rmdir(lockPath);
+		return false;
+	}
+	const journal = await readInstallJournal(lockPath, packageVersion);
+	if (processIsActive(journal.pid, journal.nonce)) {
+		return fail(
+			"SKILLS_INSTALL_BUSY",
+			"A Codex Skill installation is already active or requires manual inspection.",
+		);
+	}
+	const stagingRoot = path.join(skillsRoot, journal.stagingDirectory);
+	const identity = await captureDestinationIdentity(
+		codexHome,
+		skillsRoot,
+		lockPath,
+	);
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+	const stagingPresent = await assertOwnedDirectory(
+		stagingRoot,
+		"An interrupted Codex Skill staging path requires manual inspection.",
+	);
+	const ownedTargets: OwnedSkillTarget[] = [];
+	for (const skill of skills) {
+		const destination = path.join(skillsRoot, skill.name);
+		const destinationDetails = await lstatIfPresent(destination);
+		if (destinationDetails) {
+			if (
+				destinationDetails.isSymbolicLink() ||
+				!destinationDetails.isDirectory()
+			) {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"An interrupted Codex Skill installation requires manual inspection.",
+				);
+			}
+			const markerDetails = await lstatIfPresent(
+				path.join(destination, targetOwnerMarkerName),
+			);
+			const target = await captureOwnedSkillTarget(
+				destination,
+				skill,
+				markerDetails !== undefined,
+			);
+			try {
+				if (markerDetails) {
+					if (markerDetails.isSymbolicLink() || !markerDetails.isFile()) {
+						throw new Error("invalid owner marker");
+					}
+					await verifyRemovableSkillTarget(destination, target, journal.nonce);
+				} else {
+					await verifyInstalledSkill(destination, skill);
+					await assertOwnedSkillTarget(
+						destination,
+						target,
+						"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					);
+				}
+			} catch {
+				return fail(
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+					"An interrupted Codex Skill installation requires manual inspection.",
+				);
+			}
+			ownedTargets.push(target);
+		}
+	}
+	const installationComplete =
+		ownedTargets.length === skills.length &&
+		ownedTargets.every((target) => !target.markerPresent);
+	if (!installationComplete) {
+		for (const target of [...ownedTargets].reverse()) {
+			const destination = path.join(skillsRoot, target.skill.name);
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			await verifyRemovableSkillTarget(destination, target, journal.nonce);
+			await rm(destination, { recursive: true, force: false });
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+		}
+	}
+	await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+	await cleanupTransaction(lockPath, stagingRoot, stagingPresent);
+	return installationComplete;
+}
+
+async function commitStagedSkills(
+	skillsRoot: string,
+	skills: VerifiedSkill[],
+	nonce: string,
+	write: typeof writeFile,
+	remove: typeof rm,
+	assertStable: () => Promise<void>,
+	beforeTargetCommit?: SkillsInstallDependencies["beforeTargetCommit"],
+	afterTargetCommit?: SkillsInstallDependencies["afterTargetCommit"],
+	beforeTargetRollback?: SkillsInstallDependencies["beforeTargetRollback"],
+) {
+	const ownedTargets: OwnedSkillTarget[] = [];
+	try {
+		for (const [index, skill] of skills.entries()) {
+			await assertStable();
+			await beforeTargetCommit?.(skill.name, index);
+			await assertStable();
+			const destination = path.join(skillsRoot, skill.name);
+			try {
+				await mkdir(destination, { mode: 0o700 });
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+				return fail(
+					"SKILLS_DESTINATION_CONFLICT",
+					`Codex Skill destination already exists for: ${skill.name}. Inspect it manually; this installer never overwrites or merges.`,
+				);
+			}
+			const target = await captureOwnedSkillTarget(destination, skill, false);
+			ownedTargets.push(target);
+			await materializeReservedSkill(destination, target, nonce, write);
+			await afterTargetCommit?.(skill.name, index);
+			await assertStable();
+		}
+	} catch (error) {
+		const rollbackFailures: SupportedSkillName[] = [];
+		for (const target of [...ownedTargets].reverse()) {
+			try {
+				await beforeTargetRollback?.(target.skill.name);
+				await assertStable();
+				const destination = path.join(skillsRoot, target.skill.name);
+				await verifyRemovableSkillTarget(destination, target, nonce, true);
+				await remove(destination, { recursive: true, force: false });
+				await assertStable();
+			} catch {
+				rollbackFailures.push(target.skill.name);
+			}
+		}
+		if (rollbackFailures.length > 0) {
+			return fail(
+				"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				`Codex Skill installation rollback requires manual inspection for: ${rollbackFailures.join(", ")}.`,
+			);
+		}
+		throw error;
+	}
+}
+
+function packagedAssetRoot(): string {
+	return path.join(__dirname, "skills");
+}
+
+export function parseSkillsInstallRequest(
+	action: unknown,
+	options: Record<string, unknown>,
+): SkillsInstallRequest {
+	if (action !== "install") {
+		return fail(
+			"SKILLS_ACTION_UNSUPPORTED",
+			"Only `openapi skills install --host codex` is supported.",
+		);
+	}
+	const hosts = Array.isArray(options.host)
+		? options.host
+		: options.host === undefined
+			? []
+			: [options.host];
+	if (hosts.length === 0) {
+		return fail(
+			"SKILLS_HOST_REQUIRED",
+			"`--host codex` is required; only the Codex Host is supported.",
+		);
+	}
+	if (hosts.length > 1) {
+		return fail(
+			"SKILLS_HOST_DUPLICATE",
+			"`--host` must be specified exactly once; only the Codex Host is supported.",
+		);
+	}
+	if (
+		hosts[0] === true ||
+		hosts[0] === false ||
+		typeof hosts[0] !== "string" ||
+		hosts[0].length === 0
+	) {
+		return fail(
+			"SKILLS_HOST_EMPTY",
+			"`--host` requires the value `codex`; only the Codex Host is supported.",
+		);
+	}
+	if (hosts[0] !== "codex") {
+		return fail(
+			"SKILLS_HOST_UNSUPPORTED",
+			`Unsupported Skill Host ${JSON.stringify(hosts[0])}; only the Codex Host is supported.`,
+		);
+	}
+	return {
+		dryRun: options.dryRun === true,
+		json: options.json === true,
+	};
+}
+
+export async function installCodexSkills(
+	request: SkillsInstallRequest,
+	packageVersion: string,
+	dependencies: SkillsInstallDependencies = {},
+): Promise<SkillsInstallOutput> {
+	try {
+		const verifiedSkills = await verifyPackagedSkills(
+			dependencies.assetRoot ?? packagedAssetRoot(),
+			packageVersion,
+		);
+		const environment = dependencies.environment ?? process.env;
+		const codexHome = resolveCodexHome(
+			environment,
+			dependencies.homeDirectory ?? homedir,
+		);
+		const skillsRoot = path.join(codexHome, "skills");
+		if (path.relative(codexHome, skillsRoot) !== "skills") {
+			return fail(
+				"SKILLS_DESTINATION_INVALID",
+				"The Codex Skill destination escapes CODEX_HOME.",
+			);
+		}
+		await preflightDestination(codexHome, skillsRoot, {
+			checkConflicts: false,
+			checkLock: false,
+		});
+		const recoveredComplete =
+			!request.dryRun &&
+			(await recoverInterruptedInstallation(
+				codexHome,
+				skillsRoot,
+				packageVersion,
+				verifiedSkills,
+			));
+		const output: SkillsInstallOutput = {
+			success: true,
+			command: "skills install",
+			mode: request.dryRun ? "dry-run" : "install",
+			host: "codex",
+			packageVersion,
+			source: "packaged-npm-assets",
+			destinationRoot: skillsRoot,
+			skills: [...supportedSkillNames],
+			actions: supportedSkillNames.map((skill) => ({
+				action: "install",
+				skill,
+				destination: path.join(skillsRoot, skill),
+			})),
+			installed: request.dryRun ? [] : [...supportedSkillNames],
+			restartRequired: true,
+		};
+		if (recoveredComplete) return output;
+		const initialState = await preflightDestination(codexHome, skillsRoot);
+		if (request.dryRun) return output;
+
+		let lockAcquired = false;
+		let journalWritten = false;
+		let stagingCreated = false;
+		let preserveTransaction = false;
+		let identity: DestinationIdentity | undefined;
+		let installed = false;
+		const nonce = validateTransactionNonce(
+			(dependencies.transactionNonce ?? randomUUID)(),
+		);
+		const lockPath = path.join(skillsRoot, installLockName);
+		const stagingRoot = path.join(
+			skillsRoot,
+			`${stagingDirectoryPrefix}${nonce}`,
+		);
+		try {
+			await mkdir(skillsRoot, { recursive: true, mode: 0o700 });
+			const createdCodexHome = await lstat(codexHome);
+			const createdSkillsRoot = await lstat(skillsRoot);
+			if (
+				createdCodexHome.isSymbolicLink() ||
+				!createdCodexHome.isDirectory() ||
+				createdSkillsRoot.isSymbolicLink() ||
+				!createdSkillsRoot.isDirectory()
+			) {
+				return fail(
+					"SKILLS_DESTINATION_INVALID",
+					"The Codex Skill destination changed during installation.",
+				);
+			}
+			try {
+				await mkdir(lockPath, { mode: 0o700 });
+				lockAcquired = true;
+			} catch {
+				return fail(
+					"SKILLS_INSTALL_BUSY",
+					"A Codex Skill installation is already active or requires manual inspection.",
+				);
+			}
+			identity = await captureDestinationIdentity(
+				codexHome,
+				skillsRoot,
+				lockPath,
+			);
+			activeTransactionNonces.add(nonce);
+			await writeInstallJournal(lockPath, {
+				schemaVersion: 1,
+				packageVersion,
+				pid: dependencies.processId ?? process.pid,
+				nonce,
+				stagingDirectory: path.basename(stagingRoot),
+				skills: [...supportedSkillNames],
+			});
+			journalWritten = true;
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			const lockedState = await preflightDestination(codexHome, skillsRoot, {
+				checkLock: false,
+			});
+			if (!lockedState.skillsRootPresent) {
+				return fail(
+					"SKILLS_DESTINATION_INVALID",
+					"The Codex Skill destination changed during installation.",
+				);
+			}
+			await dependencies.beforeStaging?.();
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			await mkdir(stagingRoot, { mode: 0o700 });
+			stagingCreated = true;
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			const fileWriter = dependencies.writeFile ?? writeFile;
+			await writeStagedSkills(stagingRoot, verifiedSkills, fileWriter);
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			for (const skill of verifiedSkills) {
+				await verifyInstalledSkill(path.join(stagingRoot, skill.name), skill);
+			}
+			await assertDestinationStable(codexHome, skillsRoot, lockPath, identity);
+			await commitStagedSkills(
+				skillsRoot,
+				verifiedSkills,
+				nonce,
+				fileWriter,
+				dependencies.remove ?? rm,
+				() =>
+					assertDestinationStable(
+						codexHome,
+						skillsRoot,
+						lockPath,
+						identity as DestinationIdentity,
+					),
+				dependencies.beforeTargetCommit,
+				dependencies.afterTargetCommit,
+				dependencies.beforeTargetRollback,
+			);
+			installed = true;
+		} catch (error) {
+			if (
+				error instanceof SkillsInstallError &&
+				[
+					"SKILLS_DESTINATION_CHANGED",
+					"SKILLS_INSTALL_RECOVERY_REQUIRED",
+				].includes(error.code)
+			) {
+				preserveTransaction = true;
+			}
+			throw error;
+		} finally {
+			activeTransactionNonces.delete(nonce);
+			const cleanupSafe =
+				!identity ||
+				(await destinationIsStable(codexHome, skillsRoot, lockPath, identity));
+			if (lockAcquired && !preserveTransaction && cleanupSafe) {
+				if (journalWritten) {
+					await cleanupTransaction(lockPath, stagingRoot, stagingCreated);
+				} else {
+					await rmdir(lockPath);
+				}
+			}
+			if (
+				!installed &&
+				!preserveTransaction &&
+				cleanupSafe &&
+				!initialState.skillsRootPresent
+			) {
+				await rmdir(skillsRoot).catch(() => undefined);
+			}
+			if (
+				!installed &&
+				!preserveTransaction &&
+				cleanupSafe &&
+				!initialState.codexHomePresent
+			) {
+				await rmdir(codexHome).catch(() => undefined);
+			}
+		}
+		return output;
+	} catch (error) {
+		if (error instanceof SkillsInstallError) throw error;
+		throw new SkillsInstallError(
+			"SKILLS_INSTALL_FAILED",
+			"Codex Skill installation failed safely; no overwrite was attempted.",
+		);
+	}
+}
+
+export function skillsInstallHumanOutput(
+	output: SkillsInstallOutput,
+): string[] {
+	if (output.mode === "dry-run") {
+		return [
+			"Codex Skill install plan (dry run)",
+			`Package version: ${output.packageVersion}`,
+			"Source: packaged npm assets (offline)",
+			"Destination: Codex user Skills directory",
+			"Skills:",
+			...output.skills.map((name) => `- ${name}`),
+			"No files were written.",
+			"Restart Codex after applying this plan.",
+		];
+	}
+	return [
+		"Installed Codex Skills:",
+		...output.installed.map((name) => `- ${name}`),
+		"restartRequired: true",
+		"Restart Codex to load the installed Skills.",
+	];
+}

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -4,6 +4,8 @@
 
 ```sh
 pnpm add -D openapi-to
+pnpm exec openapi skills install --host codex --dry-run
+pnpm exec openapi skills install --host codex
 pnpm exec openapi --help
 pnpm exec openapi-to-mcp --help
 ```
@@ -18,6 +20,12 @@ The package installs `openapi` and `openapi-to` as aliases of the same CLI entry
 - `pluginMSW`
 
 Faker, NestJS, and React Query generators are not included.
+
+The explicit `skills install` command copies the two version-matched consumer
+Skills from the installed npm package to `$CODEX_HOME/skills` (default
+`~/.codex/skills`) without network access or overwrite. Restart Codex after
+installation. Package installation and `openapi init` do not install Skills,
+and the installer does not configure MCP.
 
 The aggregate depends on `@openapi-to/mcp` at runtime only to provide the shared command. MCP server APIs remain available from `@openapi-to/mcp` and `@openapi-to/mcp/cli`; they are intentionally not re-exported from the `openapi-to` top-level JavaScript API.
 

--- a/packages/openapi/bin/openapi.js
+++ b/packages/openapi/bin/openapi.js
@@ -4,13 +4,30 @@ import semver from 'semver'
 
 
 const requiredVersion =  '>=20.0.0';
+const globalBooleanOptions = new Set([
+  '--debug',
+  '--json',
+  '--no-debug',
+  '--no-json',
+])
+
+function topLevelCommand(argv) {
+  for (const argument of argv.slice(2)) {
+    if (argument === '--') return undefined
+    const optionName = argument.split('=', 1)[0]
+    if (globalBooleanOptions.has(optionName)) continue
+    return argument
+  }
+  return undefined
+}
+
 if (!semver.satisfies(process.version, requiredVersion)) {
   console.error(`Error: This tool requires Node.js ${requiredVersion}, but you are using ${process.version}`);
   process.exitCode = 1;
 } else {
   import('@openapi-to/cli').then(async({run}) => {
     const {updateVersionNotifier} = await import('../dist/utils.js')
-    const isSkillsCommand = process.argv[2] === 'skills'
+    const isSkillsCommand = topLevelCommand(process.argv) === 'skills'
     if (!isSkillsCommand && !process.argv.includes('--json')) updateVersionNotifier()
     await run(process.argv)
   }).catch((error) => {

--- a/packages/openapi/bin/openapi.js
+++ b/packages/openapi/bin/openapi.js
@@ -10,7 +10,8 @@ if (!semver.satisfies(process.version, requiredVersion)) {
 } else {
   import('@openapi-to/cli').then(async({run}) => {
     const {updateVersionNotifier} = await import('../dist/utils.js')
-    if (!process.argv.includes('--json')) updateVersionNotifier()
+    const isSkillsCommand = process.argv[2] === 'skills'
+    if (!isSkillsCommand && !process.argv.includes('--json')) updateVersionNotifier()
     await run(process.argv)
   }).catch((error) => {
     console.error(error instanceof Error ? error.message : String(error))

--- a/scripts/build-consumer-skill-assets.mjs
+++ b/scripts/build-consumer-skill-assets.mjs
@@ -1,0 +1,212 @@
+import { createHash } from "node:crypto";
+import {
+	lstat,
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+
+export const consumerSkillNames = ["openapi-to-generate", "openapi-to-setup"];
+
+function compareText(left, right) {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function validateDistributionRelativePath(relativePath) {
+	if (
+		typeof relativePath !== "string" ||
+		relativePath.length === 0 ||
+		relativePath.includes("\\") ||
+		relativePath.includes("\0") ||
+		path.posix.isAbsolute(relativePath) ||
+		path.posix.normalize(relativePath) !== relativePath ||
+		relativePath === "." ||
+		relativePath.startsWith("../") ||
+		relativePath.split("/").some((segment) => segment.length === 0)
+	) {
+		throw new Error(
+			`Unsafe consumer Skill distribution path: ${JSON.stringify(relativePath)}`,
+		);
+	}
+	return relativePath;
+}
+
+function assertCanonicalSkillNames(skillNames) {
+	const sorted = [...skillNames].sort(compareText);
+	if (
+		JSON.stringify(sorted) !==
+		JSON.stringify([...consumerSkillNames].sort(compareText))
+	) {
+		throw new Error(
+			`Consumer Skill asset build must contain only: ${consumerSkillNames.join(", ")}`,
+		);
+	}
+	return sorted;
+}
+
+async function readCanonicalFiles(skillRoot, relativeDirectory = "") {
+	const directory = path.join(
+		skillRoot,
+		...relativeDirectory.split("/").filter(Boolean),
+	);
+	const entries = (await readdir(directory, { withFileTypes: true })).sort(
+		(left, right) => compareText(left.name, right.name),
+	);
+	const files = [];
+	for (const entry of entries) {
+		const relativePath = validateDistributionRelativePath(
+			relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name,
+		);
+		const absolutePath = path.join(skillRoot, ...relativePath.split("/"));
+		const details = await lstat(absolutePath);
+		if (details.isSymbolicLink()) {
+			throw new Error(
+				`Consumer Skill source must not contain symlinks: ${relativePath}`,
+			);
+		}
+		if (details.isDirectory()) {
+			files.push(...(await readCanonicalFiles(skillRoot, relativePath)));
+			continue;
+		}
+		if (!details.isFile()) {
+			throw new Error(
+				`Consumer Skill source must contain only regular files: ${relativePath}`,
+			);
+		}
+		const bytes = await readFile(absolutePath);
+		if (bytes.byteLength === 0) {
+			throw new Error(
+				`Consumer Skill source files must not be empty: ${relativePath}`,
+			);
+		}
+		files.push({ relativePath, bytes });
+	}
+	return files;
+}
+
+async function replaceDirectory(stagingDirectory, destinationDirectory) {
+	const parentDirectory = path.dirname(destinationDirectory);
+	let backupContainer;
+	let backupDirectory;
+	try {
+		const existing = await lstat(destinationDirectory).catch((error) => {
+			if (error?.code === "ENOENT") return undefined;
+			throw error;
+		});
+		if (existing) {
+			backupContainer = await mkdtemp(
+				path.join(parentDirectory, ".consumer-skills-backup-"),
+			);
+			backupDirectory = path.join(backupContainer, "previous");
+			await rename(destinationDirectory, backupDirectory);
+		}
+		try {
+			await rename(stagingDirectory, destinationDirectory);
+		} catch (error) {
+			if (backupDirectory) {
+				await rename(backupDirectory, destinationDirectory);
+			}
+			throw error;
+		}
+	} finally {
+		if (backupContainer) {
+			await rm(backupContainer, { recursive: true, force: true });
+		}
+	}
+}
+
+export async function buildConsumerSkillAssets(options = {}) {
+	const sourceRoot =
+		options.sourceRoot ?? path.join(repositoryRoot, ".agents", "skills");
+	const packageDirectory =
+		options.packageDirectory ?? path.join(repositoryRoot, "packages", "cli");
+	const outputDirectory =
+		options.outputDirectory ?? path.join(packageDirectory, "dist", "skills");
+	const skillNames = assertCanonicalSkillNames(
+		options.skillNames ?? consumerSkillNames,
+	);
+	const packageManifest = JSON.parse(
+		await readFile(path.join(packageDirectory, "package.json"), "utf8"),
+	);
+	if (
+		typeof packageManifest.version !== "string" ||
+		packageManifest.version.length === 0
+	) {
+		throw new Error("@openapi-to/cli package version is missing.");
+	}
+
+	const outputParent = path.dirname(outputDirectory);
+	await mkdir(outputParent, { recursive: true });
+	const stagingDirectory = await mkdtemp(
+		path.join(outputParent, ".consumer-skills-build-"),
+	);
+	try {
+		const skills = [];
+		for (const name of skillNames) {
+			const skillRoot = path.join(sourceRoot, name);
+			const rootDetails = await lstat(skillRoot);
+			if (rootDetails.isSymbolicLink() || !rootDetails.isDirectory()) {
+				throw new Error(
+					`Consumer Skill source root must be a real directory: ${name}`,
+				);
+			}
+			const canonicalFiles = await readCanonicalFiles(skillRoot);
+			if (
+				!canonicalFiles.some(({ relativePath }) => relativePath === "SKILL.md")
+			) {
+				throw new Error(`Consumer Skill ${name} is missing SKILL.md.`);
+			}
+			const files = [];
+			for (const { relativePath, bytes } of canonicalFiles) {
+				const destination = path.join(
+					stagingDirectory,
+					name,
+					...relativePath.split("/"),
+				);
+				await mkdir(path.dirname(destination), { recursive: true });
+				await writeFile(destination, bytes, { flag: "wx", mode: 0o644 });
+				files.push({
+					path: relativePath,
+					size: bytes.byteLength,
+					sha256: createHash("sha256").update(bytes).digest("hex"),
+				});
+			}
+			skills.push({ name, files });
+		}
+		const manifest = {
+			schemaVersion: 1,
+			packageVersion: packageManifest.version,
+			skills,
+		};
+		await writeFile(
+			path.join(stagingDirectory, "manifest.json"),
+			`${JSON.stringify(manifest, null, 2)}\n`,
+			{ flag: "wx", mode: 0o644 },
+		);
+		await replaceDirectory(stagingDirectory, outputDirectory);
+		return manifest;
+	} finally {
+		await rm(stagingDirectory, { recursive: true, force: true });
+	}
+}
+
+if (
+	process.argv[1] &&
+	path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+	const manifest = await buildConsumerSkillAssets();
+	process.stdout.write(
+		`Built ${manifest.skills.length} consumer Skills for @openapi-to/cli@${manifest.packageVersion}.\n`,
+	);
+}

--- a/scripts/build-consumer-skill-assets.node-test.mjs
+++ b/scripts/build-consumer-skill-assets.node-test.mjs
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+	mkdir,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	symlink,
+	writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+	buildConsumerSkillAssets,
+	consumerSkillNames,
+	validateDistributionRelativePath,
+} from "./build-consumer-skill-assets.mjs";
+
+const repositoryRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+const temporaryRoots = [];
+
+after(async () => {
+	await Promise.all(
+		temporaryRoots.map((root) => rm(root, { recursive: true, force: true })),
+	);
+});
+
+async function temporaryRoot(prefix) {
+	const root = await mkdtemp(path.join(tmpdir(), prefix));
+	temporaryRoots.push(root);
+	return root;
+}
+
+async function filesBelow(root, relativeDirectory = "") {
+	const directory = path.join(
+		root,
+		...relativeDirectory.split("/").filter(Boolean),
+	);
+	const entries = (await readdir(directory, { withFileTypes: true })).sort(
+		(left, right) =>
+			left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+	);
+	const files = [];
+	for (const entry of entries) {
+		const relativePath = relativeDirectory
+			? `${relativeDirectory}/${entry.name}`
+			: entry.name;
+		if (entry.isDirectory()) {
+			files.push(...(await filesBelow(root, relativePath)));
+		} else if (entry.isFile()) {
+			const bytes = await readFile(path.join(root, ...relativePath.split("/")));
+			files.push({
+				path: relativePath,
+				size: bytes.byteLength,
+				sha256: createHash("sha256").update(bytes).digest("hex"),
+				bytes,
+			});
+		}
+	}
+	return files;
+}
+
+test("builds exact, versioned, byte-stable assets from the two canonical Skills", async () => {
+	const root = await temporaryRoot("openapi-to-skill-assets-");
+	const outputDirectory = path.join(root, "dist", "skills");
+	const options = {
+		sourceRoot: path.join(repositoryRoot, ".agents", "skills"),
+		packageDirectory: path.join(repositoryRoot, "packages", "cli"),
+		outputDirectory,
+	};
+	const first = await buildConsumerSkillAssets(options);
+	const manifestBytes = await readFile(
+		path.join(outputDirectory, "manifest.json"),
+	);
+	const cliManifest = JSON.parse(
+		await readFile(
+			path.join(repositoryRoot, "packages/cli/package.json"),
+			"utf8",
+		),
+	);
+	assert.equal(first.schemaVersion, 1);
+	assert.equal(first.packageVersion, cliManifest.version);
+	assert.deepEqual(
+		first.skills.map(({ name }) => name),
+		consumerSkillNames,
+	);
+
+	for (const skill of first.skills) {
+		const canonical = await filesBelow(
+			path.join(repositoryRoot, ".agents", "skills", skill.name),
+		);
+		const distributed = await filesBelow(
+			path.join(outputDirectory, skill.name),
+		);
+		assert.deepEqual(
+			distributed.map(({ path, size, sha256 }) => ({ path, size, sha256 })),
+			canonical.map(({ path, size, sha256 }) => ({ path, size, sha256 })),
+		);
+		for (const [index, file] of distributed.entries()) {
+			assert.deepEqual(file.bytes, canonical[index].bytes);
+		}
+		assert.deepEqual(
+			skill.files,
+			canonical.map(({ path, size, sha256 }) => ({ path, size, sha256 })),
+		);
+	}
+
+	await writeFile(path.join(outputDirectory, "stale.txt"), "stale\n");
+	const second = await buildConsumerSkillAssets(options);
+	assert.deepEqual(second, first);
+	assert.deepEqual(
+		await readFile(path.join(outputDirectory, "manifest.json")),
+		manifestBytes,
+	);
+	assert.equal(
+		(await filesBelow(outputDirectory)).some(
+			({ path }) => path === "stale.txt",
+		),
+		false,
+	);
+});
+
+test("rejects symlinks in a canonical Skill before replacing existing assets", async (t) => {
+	const root = await temporaryRoot("openapi-to-skill-symlink-");
+	const sourceRoot = path.join(root, "source");
+	const packageDirectory = path.join(root, "package");
+	const outputDirectory = path.join(packageDirectory, "dist", "skills");
+	for (const name of consumerSkillNames) {
+		await mkdir(path.join(sourceRoot, name), { recursive: true });
+		await writeFile(path.join(sourceRoot, name, "SKILL.md"), `# ${name}\n`);
+	}
+	await mkdir(outputDirectory, { recursive: true });
+	await writeFile(path.join(outputDirectory, "sentinel.txt"), "preserved\n");
+	await writeFile(
+		path.join(packageDirectory, "package.json"),
+		'{"name":"@openapi-to/cli","version":"1.2.3"}\n',
+	);
+	try {
+		await symlink(
+			path.join(sourceRoot, "openapi-to-generate"),
+			path.join(sourceRoot, "openapi-to-setup", "linked"),
+			process.platform === "win32" ? "junction" : "dir",
+		);
+	} catch (error) {
+		if (
+			process.platform === "win32" &&
+			["EPERM", "EACCES"].includes(error?.code)
+		) {
+			t.skip("Windows runner does not permit test symlink creation.");
+			return;
+		}
+		throw error;
+	}
+	await assert.rejects(
+		buildConsumerSkillAssets({
+			sourceRoot,
+			packageDirectory,
+			outputDirectory,
+		}),
+		/must not contain symlinks/,
+	);
+	assert.equal(
+		await readFile(path.join(outputDirectory, "sentinel.txt"), "utf8"),
+		"preserved\n",
+	);
+});
+
+test("rejects empty canonical files before replacing existing assets", async () => {
+	const root = await temporaryRoot("openapi-to-skill-empty-");
+	const sourceRoot = path.join(root, "source");
+	const packageDirectory = path.join(root, "package");
+	const outputDirectory = path.join(packageDirectory, "dist", "skills");
+	for (const name of consumerSkillNames) {
+		await mkdir(path.join(sourceRoot, name), { recursive: true });
+		await writeFile(path.join(sourceRoot, name, "SKILL.md"), `# ${name}\n`);
+	}
+	await writeFile(path.join(sourceRoot, "openapi-to-generate", "empty.md"), "");
+	await mkdir(outputDirectory, { recursive: true });
+	await writeFile(path.join(outputDirectory, "sentinel.txt"), "preserved\n");
+	await writeFile(
+		path.join(packageDirectory, "package.json"),
+		'{"name":"@openapi-to/cli","version":"1.2.3"}\n',
+	);
+	await assert.rejects(
+		buildConsumerSkillAssets({
+			sourceRoot,
+			packageDirectory,
+			outputDirectory,
+		}),
+		/must not be empty/,
+	);
+	assert.equal(
+		await readFile(path.join(outputDirectory, "sentinel.txt"), "utf8"),
+		"preserved\n",
+	);
+});
+
+test("rejects traversal, platform separators, and non-canonical Skill sets", async () => {
+	for (const candidate of [
+		"../escape",
+		"references\\escape.md",
+		"/absolute",
+		"references//double.md",
+		"./SKILL.md",
+	]) {
+		assert.throws(
+			() => validateDistributionRelativePath(candidate),
+			/Unsafe consumer Skill distribution path/,
+		);
+	}
+	const root = await temporaryRoot("openapi-to-skill-names-");
+	await assert.rejects(
+		buildConsumerSkillAssets({
+			sourceRoot: root,
+			packageDirectory: root,
+			outputDirectory: path.join(root, "dist", "skills"),
+			skillNames: ["../escape"],
+		}),
+		/must contain only/,
+	);
+});

--- a/scripts/ci-diagnostics/ci-diagnostics.node-test.mjs
+++ b/scripts/ci-diagnostics/ci-diagnostics.node-test.mjs
@@ -1835,6 +1835,19 @@ test("workflow contract keeps finalizers, failure artifacts, gates, and matrices
 		id: "pnpm-launcher",
 		label: "Verify pnpm launcher",
 	});
+	assert.deepEqual(
+		getPlan("a1-contracts").commands.slice(2, 4),
+		[
+			{
+				id: "codex-skills-installer-tests",
+				label: "Run focused Codex Skill installer tests",
+			},
+			{
+				id: "codex-skills-installer-built-bin",
+				label: "Run built Codex Skill installer smoke",
+			},
+		],
+	);
 	const e2e = workflows.find(({ name }) => name === "e2e.yaml").contents;
 	assert.equal(
 		[...e2e.matchAll(/os: \[ubuntu-latest, windows-latest, macos-latest\]/g)]

--- a/scripts/ci-diagnostics/plans.mjs
+++ b/scripts/ci-diagnostics/plans.mjs
@@ -86,6 +86,14 @@ export const plans = Object.freeze({
 		commands: [
 			command("pnpm-launcher", "Verify pnpm launcher"),
 			command("build", "Build packages"),
+			command(
+				"codex-skills-installer-tests",
+				"Run focused Codex Skill installer tests",
+			),
+			command(
+				"codex-skills-installer-built-bin",
+				"Run built Codex Skill installer smoke",
+			),
 			command("a1-contracts", "Run A1 focused contracts"),
 			command("cli-openapi-help", "Verify openapi CLI alias"),
 			command("cli-openapi-to-version", "Verify openapi-to CLI alias"),

--- a/scripts/codex-skills-installer-cross-platform-smoke.mjs
+++ b/scripts/codex-skills-installer-cross-platform-smoke.mjs
@@ -1,0 +1,221 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(
+	path.dirname(fileURLToPath(import.meta.url)),
+	"..",
+);
+const consumerRoot = path.join(repositoryRoot, "e2e", "common");
+const suffix = process.platform === "win32" ? ".cmd" : "";
+
+function runAlias(
+	name,
+	args,
+	environment,
+	expectedStatus = 0,
+	parseJson = true,
+) {
+	const executable = path.join(
+		consumerRoot,
+		"node_modules",
+		".bin",
+		`${name}${suffix}`,
+	);
+	const childEnvironment = {
+		...process.env,
+		CI: "1",
+		...environment,
+	};
+	delete childEnvironment.NO_UPDATE_NOTIFIER;
+	const result = spawnSync(executable, args, {
+		cwd: consumerRoot,
+		encoding: "utf8",
+		env: childEnvironment,
+		shell: process.platform === "win32",
+	});
+	if (result.error) throw result.error;
+	if (result.status !== expectedStatus) {
+		throw new Error(
+			`${name} ${args.join(" ")} exited with ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+		);
+	}
+	if (result.stderr !== "") {
+		throw new Error(`${name} wrote unexpected stderr: ${result.stderr}`);
+	}
+	return parseJson ? JSON.parse(result.stdout) : result;
+}
+
+async function hashes(root, manifest) {
+	const result = {};
+	for (const skill of manifest.skills) {
+		for (const file of skill.files) {
+			const key = `${skill.name}/${file.path}`;
+			const bytes = await readFile(
+				path.join(root, skill.name, ...file.path.split("/")),
+			);
+			result[key] = createHash("sha256").update(bytes).digest("hex");
+		}
+	}
+	return result;
+}
+
+const temporaryRoot = await mkdtemp(
+	path.join(tmpdir(), "openapi-to-codex-skills-cross-platform-"),
+);
+const codexHome = path.join(temporaryRoot, "Codex Home with spaces 空格");
+const notifierConfigRoots = [
+	path.join(temporaryRoot, "User Home"),
+	path.join(temporaryRoot, "XDG Config"),
+	path.join(temporaryRoot, "App Data"),
+	path.join(temporaryRoot, "Local App Data"),
+];
+const environment = {
+	CODEX_HOME: codexHome,
+	HOME: notifierConfigRoots[0],
+	USERPROFILE: notifierConfigRoots[0],
+	XDG_CONFIG_HOME: notifierConfigRoots[1],
+	APPDATA: notifierConfigRoots[2],
+	LOCALAPPDATA: notifierConfigRoots[3],
+};
+try {
+	const openapiBinary = path.join(
+		consumerRoot,
+		"node_modules",
+		".bin",
+		`openapi${suffix}`,
+	);
+	const openapiToBinary = path.join(
+		consumerRoot,
+		"node_modules",
+		".bin",
+		`openapi-to${suffix}`,
+	);
+	await Promise.all([access(openapiBinary), access(openapiToBinary)]);
+	const manifest = JSON.parse(
+		await readFile(
+			path.join(
+				repositoryRoot,
+				"packages",
+				"cli",
+				"dist",
+				"skills",
+				"manifest.json",
+			),
+			"utf8",
+		),
+	);
+	const packagedRoot = path.join(
+		repositoryRoot,
+		"packages",
+		"cli",
+		"dist",
+		"skills",
+	);
+	const humanDryRun = runAlias(
+		"openapi",
+		["skills", "install", "--host", "codex", "--dry-run"],
+		environment,
+		0,
+		false,
+	);
+	if (
+		!humanDryRun.stdout.includes("No files were written.") ||
+		!humanDryRun.stdout.includes("Restart Codex")
+	) {
+		throw new Error("Cross-platform human dry-run contract failed");
+	}
+	for (const target of [codexHome, ...notifierConfigRoots]) {
+		try {
+			await access(target);
+			throw new Error(
+				"Cross-platform human dry-run wrote Codex or notifier state",
+			);
+		} catch (error) {
+			if (!(error && error.code === "ENOENT")) throw error;
+		}
+	}
+	const dryRun = runAlias(
+		"openapi",
+		["skills", "install", "--host", "codex", "--dry-run", "--json"],
+		environment,
+	);
+	if (
+		dryRun.success !== true ||
+		dryRun.mode !== "dry-run" ||
+		dryRun.restartRequired !== true
+	) {
+		throw new Error("Cross-platform Codex Skill dry-run contract failed");
+	}
+	try {
+		await access(codexHome);
+		throw new Error("Cross-platform Codex Skill dry-run created CODEX_HOME");
+	} catch (error) {
+		if (!(error && error.code === "ENOENT")) throw error;
+	}
+	const installed = runAlias(
+		"openapi-to",
+		["skills", "install", "--host", "codex", "--json"],
+		environment,
+	);
+	if (
+		installed.success !== true ||
+		installed.installed?.join(",") !== "openapi-to-generate,openapi-to-setup" ||
+		installed.restartRequired !== true
+	) {
+		throw new Error("Cross-platform Codex Skill install contract failed");
+	}
+	const installedRoot = path.join(codexHome, "skills");
+	if (
+		(await readdir(installedRoot)).sort().join(",") !==
+		"openapi-to-generate,openapi-to-setup"
+	) {
+		throw new Error("Cross-platform Codex Skill installed file set failed");
+	}
+	if (
+		JSON.stringify(await hashes(installedRoot, manifest)) !==
+		JSON.stringify(await hashes(packagedRoot, manifest))
+	) {
+		throw new Error("Cross-platform Codex Skill installed byte check failed");
+	}
+	const second = runAlias(
+		"openapi",
+		["skills", "install", "--host", "codex", "--json"],
+		environment,
+		1,
+	);
+	if (
+		second.success !== false ||
+		!second.diagnostics?.some(
+			({ code }) => code === "SKILLS_DESTINATION_CONFLICT",
+		)
+	) {
+		throw new Error("Cross-platform Codex Skill conflict check failed");
+	}
+	process.stdout.write(
+		`${JSON.stringify({
+			success: true,
+			platform: process.platform,
+			binarySuffix: suffix,
+			codexHomeContainsSpaces: true,
+			skills: manifest.skills.length,
+			files: manifest.skills.flatMap(({ files }) => files).length,
+			checks: [
+				"built-openapi-alias",
+				"built-openapi-to-alias",
+				process.platform === "win32" ? "windows-cmd-entry" : "posix-bin-entry",
+				"codex-home-spaces-unicode",
+				"human-dry-run-no-notifier",
+				"dry-run-no-write",
+				"two-skill-install",
+				"installed-byte-verification",
+				"existing-destination-rejection",
+			],
+		})}\n`,
+	);
+} finally {
+	await rm(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/codex-skills-installer-cross-platform-smoke.mjs
+++ b/scripts/codex-skills-installer-cross-platform-smoke.mjs
@@ -1,6 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import {
+	access,
+	mkdtemp,
+	readdir,
+	readFile,
+	rm,
+	writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -73,6 +80,18 @@ const notifierConfigRoots = [
 	path.join(temporaryRoot, "App Data"),
 	path.join(temporaryRoot, "Local App Data"),
 ];
+const networkTrace = path.join(temporaryRoot, "network-attempted");
+const networkGuard = path.join(temporaryRoot, "deny-network.cjs");
+await writeFile(
+	networkGuard,
+	`const fs = require("node:fs");
+const net = require("node:net");
+net.Socket.prototype.connect = function () {
+  fs.appendFileSync(process.env.OPENAPI_TO_NETWORK_TRACE, "attempted\\n");
+  throw new Error("Unexpected network access in Codex Skill installer smoke");
+};
+`,
+);
 const environment = {
 	CODEX_HOME: codexHome,
 	HOME: notifierConfigRoots[0],
@@ -80,6 +99,10 @@ const environment = {
 	XDG_CONFIG_HOME: notifierConfigRoots[1],
 	APPDATA: notifierConfigRoots[2],
 	LOCALAPPDATA: notifierConfigRoots[3],
+	NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${networkGuard}`]
+		.filter(Boolean)
+		.join(" "),
+	OPENAPI_TO_NETWORK_TRACE: networkTrace,
 };
 try {
 	const openapiBinary = path.join(
@@ -138,6 +161,31 @@ try {
 			if (!(error && error.code === "ENOENT")) throw error;
 		}
 	}
+	for (const [alias, argumentsList] of [
+		[
+			"openapi",
+			["--debug", "skills", "install", "--host", "codex", "--dry-run"],
+		],
+		[
+			"openapi-to",
+			["--debug", "skills", "install", "--host", "codex", "--dry-run"],
+		],
+	]) {
+		const result = runAlias(alias, argumentsList, environment, 0, false);
+		if (!result.stdout.includes("No files were written.")) {
+			throw new Error(`${alias} global-debug Skill dry-run contract failed`);
+		}
+		for (const target of [codexHome, ...notifierConfigRoots, networkTrace]) {
+			try {
+				await access(target);
+				throw new Error(
+					`${alias} global-debug Skill dry-run wrote installer, notifier, or network state`,
+				);
+			} catch (error) {
+				if (!(error && error.code === "ENOENT")) throw error;
+			}
+		}
+	}
 	const dryRun = runAlias(
 		"openapi",
 		["skills", "install", "--host", "codex", "--dry-run", "--json"],
@@ -181,6 +229,12 @@ try {
 	) {
 		throw new Error("Cross-platform Codex Skill installed byte check failed");
 	}
+	try {
+		await access(networkTrace);
+		throw new Error("Cross-platform Codex Skill installer attempted network access");
+	} catch (error) {
+		if (!(error && error.code === "ENOENT")) throw error;
+	}
 	const second = runAlias(
 		"openapi",
 		["skills", "install", "--host", "codex", "--json"],
@@ -209,6 +263,8 @@ try {
 				process.platform === "win32" ? "windows-cmd-entry" : "posix-bin-entry",
 				"codex-home-spaces-unicode",
 				"human-dry-run-no-notifier",
+				"global-debug-before-skills-no-notifier",
+				"no-network-attempt",
 				"dry-run-no-write",
 				"two-skill-install",
 				"installed-byte-verification",

--- a/scripts/release/pack-install-smoke.mjs
+++ b/scripts/release/pack-install-smoke.mjs
@@ -1,4 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
 	access,
 	chmod,
@@ -43,16 +44,20 @@ function parseArguments(argumentsList) {
 const options = parseArguments(process.argv.slice(2));
 
 function run(command, args, cwd, options = {}) {
+	const environment = {
+		...process.env,
+		CI: "1",
+		NO_UPDATE_NOTIFIER: "1",
+		...options.env,
+	};
+	for (const name of options.unsetEnvironment ?? []) {
+		delete environment[name];
+	}
 	const result = spawnSync(command, args, {
 		cwd,
 		encoding: "utf8",
 		maxBuffer: 64 * 1024 * 1024,
-		env: {
-			...process.env,
-			CI: "1",
-			NO_UPDATE_NOTIFIER: "1",
-			...options.env,
-		},
+		env: environment,
 	});
 	if (result.error) throw result.error;
 	if (result.status !== (options.expectedStatus ?? 0)) {
@@ -200,6 +205,201 @@ function dependencyNames(node, names = new Set()) {
 	return names;
 }
 
+async function skillTreeHashes(root, manifest) {
+	const hashes = {};
+	for (const skill of manifest.skills) {
+		for (const file of skill.files) {
+			const key = `${skill.name}/${file.path}`;
+			const bytes = await readFile(
+				join(root, skill.name, ...file.path.split("/")),
+			);
+			hashes[key] = createHash("sha256").update(bytes).digest("hex");
+		}
+	}
+	return hashes;
+}
+
+async function runPackedCodexSkillInstallerScenario({
+	consumerRoot,
+	openapiExecutable,
+	openapiToExecutable,
+	packed,
+}) {
+	const codexHome = join(consumerRoot, "Codex Home with spaces 空格");
+	const notifierHome = join(consumerRoot, "notifier-user-home");
+	const notifierConfig = join(consumerRoot, "notifier-config");
+	const notifierAppData = join(consumerRoot, "notifier-app-data");
+	const notifierLocalAppData = join(consumerRoot, "notifier-local-app-data");
+	const environment = {
+		CODEX_HOME: codexHome,
+		HOME: notifierHome,
+		USERPROFILE: notifierHome,
+		XDG_CONFIG_HOME: notifierConfig,
+		APPDATA: notifierAppData,
+		LOCALAPPDATA: notifierLocalAppData,
+	};
+	const humanDryRun = run(
+		openapiExecutable,
+		["skills", "install", "--host", "codex", "--dry-run"],
+		consumerRoot,
+		{
+			env: environment,
+			unsetEnvironment: ["NO_UPDATE_NOTIFIER"],
+		},
+	);
+	if (
+		!humanDryRun.stdout.includes("No files were written") ||
+		!humanDryRun.stdout.includes("Restart Codex")
+	) {
+		throw new Error(
+			"Packed Codex Skill installer human dry-run contract failed",
+		);
+	}
+	for (const [label, directory] of [
+		["CODEX_HOME", codexHome],
+		["HOME", notifierHome],
+		["XDG_CONFIG_HOME", notifierConfig],
+		["APPDATA", notifierAppData],
+		["LOCALAPPDATA", notifierLocalAppData],
+	]) {
+		try {
+			await access(directory);
+			throw new Error(
+				`Packed Codex Skill installer human dry-run created ${label}`,
+			);
+		} catch (error) {
+			if (!(error && error.code === "ENOENT")) throw error;
+		}
+	}
+	const dryRun = JSON.parse(
+		run(
+			openapiExecutable,
+			["skills", "install", "--host", "codex", "--dry-run", "--json"],
+			consumerRoot,
+			{ env: environment },
+		).stdout,
+	);
+	if (
+		dryRun.success !== true ||
+		dryRun.command !== "skills install" ||
+		dryRun.mode !== "dry-run" ||
+		dryRun.host !== "codex" ||
+		dryRun.restartRequired !== true ||
+		dryRun.installed?.length !== 0
+	) {
+		throw new Error("Packed Codex Skill installer dry-run contract failed");
+	}
+	try {
+		await access(codexHome);
+		throw new Error("Packed Codex Skill installer dry-run created CODEX_HOME");
+	} catch (error) {
+		if (!(error && error.code === "ENOENT")) throw error;
+	}
+
+	const resolverPath = join(consumerRoot, "resolve-cli-skill-assets.mjs");
+	await writeFile(
+		resolverPath,
+		`import { createRequire } from "node:module";
+import path from "node:path";
+const consumerRequire = createRequire(import.meta.url);
+const aggregateEntry = consumerRequire.resolve("openapi-to");
+const aggregateRequire = createRequire(aggregateEntry);
+const cliEntry = aggregateRequire.resolve("@openapi-to/cli");
+process.stdout.write(JSON.stringify({ assetRoot: path.join(path.dirname(cliEntry), "skills") }));
+`,
+	);
+	const { assetRoot } = JSON.parse(
+		run(process.execPath, [resolverPath], consumerRoot).stdout,
+	);
+	const manifestBytes = await readFile(join(assetRoot, "manifest.json"));
+	const manifest = JSON.parse(manifestBytes);
+	const cliPackage = packed.find(({ name }) => name === "@openapi-to/cli");
+	if (
+		!cliPackage ||
+		manifest.schemaVersion !== 1 ||
+		manifest.packageVersion !== cliPackage.version ||
+		manifest.skills?.map(({ name }) => name).join(",") !==
+			"openapi-to-generate,openapi-to-setup"
+	) {
+		throw new Error("Packed Codex Skill manifest version or Skill set failed");
+	}
+	const packagedHashes = await skillTreeHashes(assetRoot, manifest);
+	const installStarted = process.hrtime.bigint();
+	const installedResult = run(
+		openapiToExecutable,
+		["skills", "install", "--host", "codex", "--json"],
+		consumerRoot,
+		{ env: environment },
+	);
+	const installMilliseconds =
+		Number(process.hrtime.bigint() - installStarted) / 1_000_000;
+	const installed = JSON.parse(installedResult.stdout);
+	if (
+		installed.success !== true ||
+		installed.mode !== "install" ||
+		installed.restartRequired !== true ||
+		installed.installed?.join(",") !== "openapi-to-generate,openapi-to-setup"
+	) {
+		throw new Error("Packed Codex Skill installer install contract failed");
+	}
+	const installedRoot = join(codexHome, "skills");
+	const installedEntries = (await readdir(installedRoot)).sort();
+	if (installedEntries.join(",") !== "openapi-to-generate,openapi-to-setup") {
+		throw new Error(
+			"Packed Codex Skill installer left an unexpected installed file set",
+		);
+	}
+	const installedHashes = await skillTreeHashes(installedRoot, manifest);
+	if (JSON.stringify(installedHashes) !== JSON.stringify(packagedHashes)) {
+		throw new Error(
+			"Packed Codex Skill installer bytes differ from packaged assets",
+		);
+	}
+	const beforeSecondInstall = JSON.stringify(installedHashes);
+	const secondInstall = run(
+		openapiExecutable,
+		["skills", "install", "--host", "codex", "--json"],
+		consumerRoot,
+		{ env: environment, expectedStatus: 1 },
+	);
+	const secondInstallOutput = JSON.parse(secondInstall.stdout);
+	if (
+		secondInstallOutput.success !== false ||
+		!secondInstallOutput.diagnostics?.some(
+			({ code }) => code === "SKILLS_DESTINATION_CONFLICT",
+		)
+	) {
+		throw new Error(
+			"Packed Codex Skill installer did not reject existing destinations",
+		);
+	}
+	if (
+		JSON.stringify(await skillTreeHashes(installedRoot, manifest)) !==
+		beforeSecondInstall
+	) {
+		throw new Error(
+			"Packed Codex Skill installer modified bytes on its second invocation",
+		);
+	}
+	const skillBytes = manifest.skills
+		.flatMap(({ files }) => files)
+		.reduce((total, { size }) => total + size, 0);
+	return {
+		package: cliPackage.name,
+		version: cliPackage.version,
+		skillCount: manifest.skills.length,
+		fileCount: manifest.skills.flatMap(({ files }) => files).length,
+		skillBytes,
+		manifestBytes: manifestBytes.byteLength,
+		installMilliseconds,
+		humanDryRunNoNotifier: true,
+		dryRun: true,
+		install: true,
+		secondInstallRejected: true,
+		installedBytesVerified: true,
+	};
+}
+
 const temporaryRoot = await mkdtemp(
 	join(tmpdir(), "openapi-to-release-smoke-"),
 );
@@ -225,6 +425,7 @@ let succeeded = false;
 let remoteFixtureServer;
 let packageBaseline;
 let setupMcpHandoff;
+let codexSkillsInstaller;
 try {
 	const packed = options.publicationManifest
 		? (
@@ -333,6 +534,12 @@ if (stderr.join("").includes("Unable to start server")) throw new Error("Aggrega
 			),
 		);
 	}
+	codexSkillsInstaller = await runPackedCodexSkillInstallerScenario({
+		consumerRoot: aggregateInstallationDirectory,
+		openapiExecutable: aggregateOnlyOpenapi,
+		openapiToExecutable: aggregateOnlyOpenapiTo,
+		packed,
+	});
 	pnpm(["exec", "openapi", "--help"], aggregateInstallationDirectory);
 	pnpm(["exec", "openapi-to", "--version"], aggregateInstallationDirectory);
 	pnpm(["exec", "openapi-to-mcp", "--help"], aggregateInstallationDirectory);
@@ -1014,11 +1221,17 @@ await writeClient.close();
 					openapiToTarballBytes: packed.find(
 						({ name }) => name === "openapi-to",
 					)?.size,
+					cliTarballBytes: packed.find(({ name }) => name === "@openapi-to/cli")
+						?.size,
 					mcpTarballBytes: packed.find(({ name }) => name === "@openapi-to/mcp")
 						?.size,
+					packagedSkillBytes: codexSkillsInstaller?.skillBytes,
+					codexSkillsInstallMilliseconds:
+						codexSkillsInstaller?.installMilliseconds,
 					...packageBaseline,
 				},
 				setupMcpHandoff,
+				codexSkillsInstaller,
 				checks: [
 					"esm",
 					"cjs",
@@ -1031,6 +1244,11 @@ await writeClient.close();
 					"aggregate-only-install",
 					"aggregate-only-mcp-stdio",
 					"aggregate-only-mcp-tool-matrix-3-8-10",
+					"packed-consumer-skills-assets",
+					"packed-codex-skills-human-dry-run-no-notifier",
+					"packed-codex-skills-dry-run",
+					"packed-codex-skills-install",
+					"packed-codex-skills-existing-destination",
 					"independent-mcp-bin-stdio",
 					"independent-mcp-tool-matrix-3-8-10",
 					"mcp-stdio",

--- a/scripts/release/pack-install-smoke.mjs
+++ b/scripts/release/pack-install-smoke.mjs
@@ -230,6 +230,18 @@ async function runPackedCodexSkillInstallerScenario({
 	const notifierConfig = join(consumerRoot, "notifier-config");
 	const notifierAppData = join(consumerRoot, "notifier-app-data");
 	const notifierLocalAppData = join(consumerRoot, "notifier-local-app-data");
+	const networkTrace = join(consumerRoot, "codex-skills-network-attempted");
+	const networkGuard = join(consumerRoot, "codex-skills-deny-network.cjs");
+	await writeFile(
+		networkGuard,
+		`const fs = require("node:fs");
+const net = require("node:net");
+net.Socket.prototype.connect = function () {
+  fs.appendFileSync(process.env.OPENAPI_TO_NETWORK_TRACE, "attempted\\n");
+  throw new Error("Unexpected network access in packed Codex Skill installer smoke");
+};
+`,
+	);
 	const environment = {
 		CODEX_HOME: codexHome,
 		HOME: notifierHome,
@@ -237,6 +249,10 @@ async function runPackedCodexSkillInstallerScenario({
 		XDG_CONFIG_HOME: notifierConfig,
 		APPDATA: notifierAppData,
 		LOCALAPPDATA: notifierLocalAppData,
+		NODE_OPTIONS: [process.env.NODE_OPTIONS, `--require=${networkGuard}`]
+			.filter(Boolean)
+			.join(" "),
+		OPENAPI_TO_NETWORK_TRACE: networkTrace,
 	};
 	const humanDryRun = run(
 		openapiExecutable,
@@ -269,6 +285,42 @@ async function runPackedCodexSkillInstallerScenario({
 			);
 		} catch (error) {
 			if (!(error && error.code === "ENOENT")) throw error;
+		}
+	}
+	for (const [executable, alias] of [
+		[openapiExecutable, "openapi"],
+		[openapiToExecutable, "openapi-to"],
+	]) {
+		const globalDebugDryRun = run(
+			executable,
+			["--debug", "skills", "install", "--host", "codex", "--dry-run"],
+			consumerRoot,
+			{
+				env: environment,
+				unsetEnvironment: ["NO_UPDATE_NOTIFIER"],
+			},
+		);
+		if (!globalDebugDryRun.stdout.includes("No files were written")) {
+			throw new Error(
+				`Packed ${alias} global-debug Skill dry-run contract failed`,
+			);
+		}
+		for (const [label, directory] of [
+			["CODEX_HOME", codexHome],
+			["HOME", notifierHome],
+			["XDG_CONFIG_HOME", notifierConfig],
+			["APPDATA", notifierAppData],
+			["LOCALAPPDATA", notifierLocalAppData],
+			["network trace", networkTrace],
+		]) {
+			try {
+				await access(directory);
+				throw new Error(
+					`Packed ${alias} global-debug Skill dry-run created ${label}`,
+				);
+			} catch (error) {
+				if (!(error && error.code === "ENOENT")) throw error;
+			}
 		}
 	}
 	const dryRun = JSON.parse(
@@ -355,6 +407,12 @@ process.stdout.write(JSON.stringify({ assetRoot: path.join(path.dirname(cliEntry
 			"Packed Codex Skill installer bytes differ from packaged assets",
 		);
 	}
+	try {
+		await access(networkTrace);
+		throw new Error("Packed Codex Skill installer attempted network access");
+	} catch (error) {
+		if (!(error && error.code === "ENOENT")) throw error;
+	}
 	const beforeSecondInstall = JSON.stringify(installedHashes);
 	const secondInstall = run(
 		openapiExecutable,
@@ -393,6 +451,8 @@ process.stdout.write(JSON.stringify({ assetRoot: path.join(path.dirname(cliEntry
 		manifestBytes: manifestBytes.byteLength,
 		installMilliseconds,
 		humanDryRunNoNotifier: true,
+		globalDebugDryRunNoNotifier: true,
+		networkAttempted: false,
 		dryRun: true,
 		install: true,
 		secondInstallRejected: true,
@@ -1246,6 +1306,8 @@ await writeClient.close();
 					"aggregate-only-mcp-tool-matrix-3-8-10",
 					"packed-consumer-skills-assets",
 					"packed-codex-skills-human-dry-run-no-notifier",
+					"packed-codex-skills-global-debug-no-notifier",
+					"packed-codex-skills-no-network-attempt",
 					"packed-codex-skills-dry-run",
 					"packed-codex-skills-install",
 					"packed-codex-skills-existing-destination",

--- a/scripts/release/pack-smoke-helpers.mjs
+++ b/scripts/release/pack-smoke-helpers.mjs
@@ -84,6 +84,19 @@ export async function packReleasePackages({
 		if (!filePaths.includes("package.json")) {
 			throw new Error(`${result.name} tarball is missing package.json`);
 		}
+		if (result.name === "@openapi-to/cli") {
+			for (const requiredSkillAsset of [
+				"dist/skills/manifest.json",
+				"dist/skills/openapi-to-generate/SKILL.md",
+				"dist/skills/openapi-to-setup/SKILL.md",
+			]) {
+				if (!filePaths.includes(requiredSkillAsset)) {
+					throw new Error(
+						`${result.name} tarball is missing packaged Skill asset ${requiredSkillAsset}`,
+					);
+				}
+			}
+		}
 		const packageTargets = [
 			manifest.main,
 			manifest.module,

--- a/scripts/release/verify-package-surface.mjs
+++ b/scripts/release/verify-package-surface.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { constants } from "node:fs";
 import { access, readdir, readFile, stat } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
@@ -204,6 +205,80 @@ for (const { directory, absoluteDirectory, manifest } of publicRecords) {
 		failures.push(
 			"@openapi-to/mcp: repository-only Doctor/Inspector/test scripts must not be published",
 		);
+	}
+	if (manifest.scripts?.postinstall !== undefined) {
+		failures.push(`${manifest.name}: public packages must not use postinstall`);
+	}
+	if (manifest.name === "@openapi-to/cli") {
+		const skillManifestPath = join(
+			absoluteDirectory,
+			"dist",
+			"skills",
+			"manifest.json",
+		);
+		if (!(await exists(skillManifestPath))) {
+			failures.push(
+				"@openapi-to/cli: missing generated dist/skills/manifest.json",
+			);
+		} else {
+			let skillManifest;
+			try {
+				skillManifest = JSON.parse(await readFile(skillManifestPath, "utf8"));
+			} catch {
+				failures.push(
+					"@openapi-to/cli: packaged Skill manifest is invalid JSON",
+				);
+			}
+			if (skillManifest) {
+				if (
+					skillManifest.schemaVersion !== 1 ||
+					skillManifest.packageVersion !== manifest.version ||
+					JSON.stringify(skillManifest.skills?.map(({ name }) => name)) !==
+						JSON.stringify(["openapi-to-generate", "openapi-to-setup"])
+				) {
+					failures.push(
+						"@openapi-to/cli: packaged Skill manifest version or Skill set is invalid",
+					);
+				} else {
+					for (const skill of skillManifest.skills) {
+						for (const file of skill.files ?? []) {
+							const assetPath = join(
+								absoluteDirectory,
+								"dist",
+								"skills",
+								skill.name,
+								...file.path.split("/"),
+							);
+							if (!(await exists(assetPath))) {
+								failures.push(
+									`@openapi-to/cli: missing packaged Skill file ${skill.name}/${file.path}`,
+								);
+								continue;
+							}
+							const bytes = await readFile(assetPath);
+							if (
+								bytes.byteLength !== file.size ||
+								createHash("sha256").update(bytes).digest("hex") !== file.sha256
+							) {
+								failures.push(
+									`@openapi-to/cli: packaged Skill bytes do not match manifest for ${skill.name}/${file.path}`,
+								);
+							}
+						}
+					}
+				}
+			}
+		}
+		if (
+			!manifest.scripts?.build?.includes(
+				"scripts/build-consumer-skill-assets.mjs",
+			) ||
+			manifest.scripts?.prepack !== "pnpm run build"
+		) {
+			failures.push(
+				"@openapi-to/cli: build and prepack must generate packaged consumer Skill assets",
+			);
+		}
 	}
 
 	for (const declarationPath of await declarationFiles(

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -4295,6 +4295,293 @@ export async function auditConsumerAcceptanceContracts(root = repositoryRoot) {
 	return sortedUnique(failures);
 }
 
+export async function auditCodexSkillInstallerContracts(root = repositoryRoot) {
+	const failures = [];
+	const requiredPaths = [
+		"packages/cli/src/skillsInstall.ts",
+		"scripts/build-consumer-skill-assets.mjs",
+		"scripts/build-consumer-skill-assets.node-test.mjs",
+		"scripts/codex-skills-installer-cross-platform-smoke.mjs",
+	];
+	for (const relativePath of requiredPaths) {
+		if (!(await exists(join(root, relativePath)))) {
+			failures.push(`missing Codex Skill installer asset ${relativePath}`);
+		}
+	}
+	for (const relativePath of [
+		"packages/cli/dist/skills/manifest.json",
+		"packages/cli/dist/skills/openapi-to-generate/SKILL.md",
+		"packages/cli/dist/skills/openapi-to-setup/SKILL.md",
+	]) {
+		if (await isGitTracked(root, relativePath)) {
+			failures.push(
+				`generated consumer Skill distribution must not be tracked: ${relativePath}`,
+			);
+		}
+	}
+
+	const turbo = await readJson(join(root, "turbo.json"));
+	const requiredSkillBuildInputs = [
+		".agents/skills/openapi-to-generate/**",
+		".agents/skills/openapi-to-setup/**",
+		"scripts/build-consumer-skill-assets.mjs",
+	];
+	for (const buildInput of requiredSkillBuildInputs) {
+		if (!turbo.globalDependencies?.includes(buildInput)) {
+			failures.push(
+				`Turbo globalDependencies must invalidate consumer Skill assets for ${buildInput}`,
+			);
+		}
+	}
+
+	const cliManifest = await readJson(join(root, "packages/cli/package.json"));
+	const aggregateManifest = await readJson(
+		join(root, "packages/openapi/package.json"),
+	);
+	if (
+		!cliManifest.scripts?.build?.includes(
+			"scripts/build-consumer-skill-assets.mjs",
+		) ||
+		cliManifest.scripts?.prepack !== "pnpm run build" ||
+		!cliManifest.files?.includes("dist")
+	) {
+		failures.push(
+			"@openapi-to/cli must build, prepack, and publish generated consumer Skill assets from dist",
+		);
+	}
+	for (const [name, manifest] of [
+		["@openapi-to/cli", cliManifest],
+		["openapi-to", aggregateManifest],
+	]) {
+		if (manifest.scripts?.postinstall !== undefined) {
+			failures.push(`${name} must not install Codex Skills from postinstall`);
+		}
+	}
+
+	const buildHelperPath = join(root, "scripts/build-consumer-skill-assets.mjs");
+	if (await exists(buildHelperPath)) {
+		const buildHelper = await readFile(buildHelperPath, "utf8");
+		for (const marker of [
+			'"openapi-to-generate"',
+			'"openapi-to-setup"',
+			'".agents", "skills"',
+			'"dist", "skills"',
+			'"manifest.json"',
+			'createHash("sha256")',
+		]) {
+			if (!buildHelper.includes(marker)) {
+				failures.push(
+					`consumer Skill asset builder is missing contract marker ${marker}`,
+				);
+			}
+		}
+		for (const forbidden of [
+			"implement-and-review",
+			"release-monorepo",
+			"add-cli-command",
+		]) {
+			if (buildHelper.includes(`"${forbidden}"`)) {
+				failures.push(
+					`consumer Skill asset builder must not distribute ${forbidden}`,
+				);
+			}
+		}
+	}
+
+	const cliIndexPath = join(root, "packages/cli/src/index.ts");
+	if (await exists(cliIndexPath)) {
+		const cliIndex = await readFile(cliIndexPath, "utf8");
+		for (const marker of [
+			'.command("skills <action>"',
+			'"--host [host]"',
+			'"--dry-run"',
+			'"--json"',
+			"installCodexSkills",
+		]) {
+			if (!cliIndex.includes(marker)) {
+				failures.push(`CLI Codex Skill command is missing ${marker}`);
+			}
+		}
+		for (const forbidden of [
+			"--force",
+			"--overwrite",
+			"--update",
+			"--merge",
+		]) {
+			if (cliIndex.includes(forbidden)) {
+				failures.push(
+					`CLI Codex Skill command must not expose unsupported flag ${forbidden}`,
+				);
+			}
+		}
+	}
+
+	const installerPath = join(root, "packages/cli/src/skillsInstall.ts");
+	if (await exists(installerPath)) {
+		const installer = await readFile(installerPath, "utf8");
+		for (const marker of [
+			'"codex"',
+			'"SKILLS_HOST_REQUIRED"',
+			'"SKILLS_HOST_UNSUPPORTED"',
+			'"SKILLS_DESTINATION_CONFLICT"',
+			'"SKILLS_ASSET_INTEGRITY_FAILED"',
+			"restartRequired: true",
+			'"packaged-npm-assets"',
+		]) {
+			if (!installer.includes(marker)) {
+				failures.push(
+					`Codex Skill installer is missing fail-closed marker ${marker}`,
+				);
+			}
+		}
+		for (const forbidden of [
+			/from\s+["']node:https?["']/,
+			/from\s+["']node:child_process["']/,
+			/\bfetch\s*\(/,
+			/\b(?:curl|wget|git clone)\b/,
+		]) {
+			if (forbidden.test(installer)) {
+				failures.push(
+					"Codex Skill installer must not contain network or subprocess download code",
+				);
+			}
+		}
+	}
+
+	const initPath = join(root, "packages/cli/src/init.ts");
+	if (await exists(initPath)) {
+		const initSource = await readFile(initPath, "utf8");
+		if (
+			initSource.includes("installCodexSkills") ||
+			initSource.includes("install-skills")
+		) {
+			failures.push("openapi init must not install Codex Skills");
+		}
+	}
+	const aggregateBinPath = join(root, "packages/openapi/bin/openapi.js");
+	if (await exists(aggregateBinPath)) {
+		const aggregateBin = await readFile(aggregateBinPath, "utf8");
+		if (
+			!aggregateBin.includes("isSkillsCommand") ||
+			!aggregateBin.includes(
+				"!isSkillsCommand && !process.argv.includes('--json')",
+			)
+		) {
+			failures.push(
+				"aggregate CLI aliases must skip update-notifier for every skills command",
+			);
+		}
+	}
+
+	const packHelperPath = join(root, "scripts/release/pack-smoke-helpers.mjs");
+	if (await exists(packHelperPath)) {
+		const packHelper = await readFile(packHelperPath, "utf8");
+		for (const marker of [
+			"dist/skills/manifest.json",
+			"dist/skills/openapi-to-generate/SKILL.md",
+			"dist/skills/openapi-to-setup/SKILL.md",
+		]) {
+			if (!packHelper.includes(marker)) {
+				failures.push(`packed package contract is missing ${marker}`);
+			}
+		}
+	}
+
+	const releaseSmokePath = join(root, "scripts/release/pack-install-smoke.mjs");
+	if (await exists(releaseSmokePath)) {
+		const releaseSmoke = await readFile(releaseSmokePath, "utf8");
+		for (const marker of [
+			'"packed-consumer-skills-assets"',
+			'"packed-codex-skills-human-dry-run-no-notifier"',
+			'"packed-codex-skills-dry-run"',
+			'"packed-codex-skills-install"',
+			'"packed-codex-skills-existing-destination"',
+		]) {
+			if (!releaseSmoke.includes(marker)) {
+				failures.push(`packed Codex Skill release smoke is missing ${marker}`);
+			}
+		}
+		if (
+			(releaseSmoke.match(/await\s+packReleasePackages\s*\(/g) ?? []).length !==
+			1
+		) {
+			failures.push(
+				"packed Codex Skill release smoke must reuse the single public tarball set",
+			);
+		}
+	}
+
+	const skillsInstallerPath = join(
+		root,
+		"packages/cli/src/skillsInstall.ts",
+	);
+	if (await exists(skillsInstallerPath)) {
+		const skillsInstaller = await readFile(skillsInstallerPath, "utf8");
+		for (const marker of [
+			'"SKILLS_INSTALL_RECOVERY_REQUIRED"',
+			'"SKILLS_DESTINATION_CHANGED"',
+			"captureDestinationIdentity",
+			"captureOwnedSkillTarget",
+			"recoverInterruptedInstallation",
+			"recoveredComplete",
+			"targetOwnerMarkerName",
+		]) {
+			if (!skillsInstaller.includes(marker)) {
+				failures.push(
+					`Codex Skill installer recovery contract is missing ${marker}`,
+				);
+			}
+		}
+	}
+
+	const a1Path = join(root, ".github/workflows/a1-cross-platform.yml");
+	if (await exists(a1Path)) {
+		const a1 = await readFile(a1Path, "utf8");
+		for (const marker of [
+			"pnpm --filter @openapi-to/cli test:skills-installer",
+			"node scripts/codex-skills-installer-cross-platform-smoke.mjs",
+		]) {
+			if (!a1.includes(marker)) {
+				failures.push(
+					`A1 cross-platform Codex Skill coverage is missing ${marker}`,
+				);
+			}
+		}
+	}
+
+	for (const relativeDocument of [
+		"README.md",
+		"docs/getting-started.md",
+		"docs/skills.md",
+		"docs/setup-skill.md",
+	]) {
+		const documentPath = join(root, relativeDocument);
+		if (!(await exists(documentPath))) {
+			failures.push(
+				`missing Codex Skill installer documentation ${relativeDocument}`,
+			);
+			continue;
+		}
+		const normalized = (await readFile(documentPath, "utf8")).replace(
+			/\s+/g,
+			" ",
+		);
+		for (const marker of [
+			"pnpm exec openapi skills install",
+			"$CODEX_HOME/skills",
+			"Restart Codex",
+			"openapi init",
+		]) {
+			if (!normalized.includes(marker)) {
+				failures.push(
+					`${relativeDocument} is missing Codex Skill installer marker ${marker}`,
+				);
+			}
+		}
+	}
+	return sortedUnique(failures);
+}
+
 export async function auditRepositoryContracts(root = repositoryRoot) {
 	const failures = [];
 	const rootManifest = await readJson(join(root, "package.json"));
@@ -4376,6 +4663,7 @@ export async function auditRepositoryContracts(root = repositoryRoot) {
 	failures.push(...(await auditGitHubWorkflowContexts(root)));
 	failures.push(...(await auditPublicationContracts(root)));
 	failures.push(...(await auditConsumerAcceptanceContracts(root)));
+	failures.push(...(await auditCodexSkillInstallerContracts(root)));
 
 	if (
 		rootManifest.scripts?.["version:canary"] !==

--- a/scripts/repository-contract.mjs
+++ b/scripts/repository-contract.mjs
@@ -4462,13 +4462,26 @@ export async function auditCodexSkillInstallerContracts(root = repositoryRoot) {
 	if (await exists(aggregateBinPath)) {
 		const aggregateBin = await readFile(aggregateBinPath, "utf8");
 		if (
-			!aggregateBin.includes("isSkillsCommand") ||
+			!aggregateBin.includes("function topLevelCommand(argv)") ||
+			!aggregateBin.includes(
+				"topLevelCommand(process.argv) === 'skills'",
+			) ||
 			!aggregateBin.includes(
 				"!isSkillsCommand && !process.argv.includes('--json')",
 			)
 		) {
 			failures.push(
 				"aggregate CLI aliases must skip update-notifier for every skills command",
+			);
+		}
+		if (
+			/process\.argv\s*\[\s*2\s*\]\s*===?\s*["']skills["']/.test(
+				aggregateBin,
+			) ||
+			/process\.argv\.includes\(\s*["']skills["']\s*\)/.test(aggregateBin)
+		) {
+			failures.push(
+				"aggregate CLI aliases must locate the top-level command instead of matching a fixed argv position or arbitrary value",
 			);
 		}
 	}
@@ -4493,6 +4506,8 @@ export async function auditCodexSkillInstallerContracts(root = repositoryRoot) {
 		for (const marker of [
 			'"packed-consumer-skills-assets"',
 			'"packed-codex-skills-human-dry-run-no-notifier"',
+			'"packed-codex-skills-global-debug-no-notifier"',
+			'"packed-codex-skills-no-network-attempt"',
 			'"packed-codex-skills-dry-run"',
 			'"packed-codex-skills-install"',
 			'"packed-codex-skills-existing-destination"',
@@ -4525,12 +4540,36 @@ export async function auditCodexSkillInstallerContracts(root = repositoryRoot) {
 			"recoverInterruptedInstallation",
 			"recoveredComplete",
 			"targetOwnerMarkerName",
+			"stagingOwnerMarkerName",
+			"stagingOwnerRecordName",
+			"stagingQuarantineName",
+			"writeExclusiveRecordAtomically",
+			"verifyOwnedStagingDirectory",
+			"removeVerifiedStagingTree",
+			"removeOwnedStagingDirectory",
 		]) {
 			if (!skillsInstaller.includes(marker)) {
 				failures.push(
 					`Codex Skill installer recovery contract is missing ${marker}`,
 				);
 			}
+		}
+		if (
+			(skillsInstaller.match(/cleanupTransaction\s*\(/g) ?? []).length < 3 ||
+			/rm\((?:stagingRoot|quarantineRoot),\s*\{\s*recursive: true/.test(
+				skillsInstaller,
+			) ||
+			!skillsInstaller.includes("await rename(stagingRoot, quarantineRoot)") ||
+			!skillsInstaller.includes(
+				"await removeVerifiedStagingTree(",
+			) ||
+			!skillsInstaller.includes(
+				"await verifyOwnedStagingDirectory(\n\t\tskillsRoot,\n\t\tlockPath,\n\t\tquarantineRoot,",
+			)
+		) {
+			failures.push(
+				"Codex Skill normal cleanup and interrupted recovery must atomically quarantine, reverify persisted ownership, and avoid path-based recursive staging removal",
+			);
 		}
 	}
 

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -16,6 +16,7 @@ import { promisify } from "node:util";
 import {
 	auditAgentAndSkillContracts,
 	auditCiDiagnosticsContracts,
+	auditCodexSkillInstallerContracts,
 	auditConsumerAcceptanceContracts,
 	auditGitHubWorkflowContexts,
 	auditPublicationContracts,
@@ -460,6 +461,68 @@ test("repository scripts, workspaces, docs, packages, and binary claims stay ali
 		"openapi-to-generate",
 		"openapi-to-setup",
 	]);
+});
+
+test("Codex Skill installer distribution, CLI, packed smoke, and docs stay aligned", async (t) => {
+	assert.deepEqual(await auditCodexSkillInstallerContracts(repositoryRoot), []);
+	const root = await mkdtemp(
+		join(tmpdir(), "openapi-to-codex-skills-contract-"),
+	);
+	t.after(() => rm(root, { recursive: true, force: true }));
+	for (const relativePath of [
+		"turbo.json",
+		"packages/cli/package.json",
+		"packages/openapi/package.json",
+		"packages/cli/src/index.ts",
+		"packages/cli/src/init.ts",
+		"packages/cli/src/skillsInstall.ts",
+		"packages/openapi/bin/openapi.js",
+		"scripts/build-consumer-skill-assets.mjs",
+		"scripts/build-consumer-skill-assets.node-test.mjs",
+		"scripts/codex-skills-installer-cross-platform-smoke.mjs",
+		"scripts/release/pack-smoke-helpers.mjs",
+		"scripts/release/pack-install-smoke.mjs",
+		".github/workflows/a1-cross-platform.yml",
+		"README.md",
+		"docs/getting-started.md",
+		"docs/skills.md",
+		"docs/setup-skill.md",
+	]) {
+		await writeFixtureFile(
+			root,
+			relativePath,
+			await readFile(join(repositoryRoot, relativePath), "utf8"),
+		);
+	}
+	const cliIndexPath = join(root, "packages/cli/src/index.ts");
+	await writeFile(
+		cliIndexPath,
+		(await readFile(cliIndexPath, "utf8")).replace(
+			'.command("skills <action>"',
+			'.command("removed <action>"',
+		),
+	);
+	assertFailure(
+		{ failures: await auditCodexSkillInstallerContracts(root) },
+		/CLI Codex Skill command is missing/,
+	);
+	await writeFile(
+		cliIndexPath,
+		await readFile(
+			join(repositoryRoot, "packages/cli/src/index.ts"),
+			"utf8",
+		),
+	);
+	const turboPath = join(root, "turbo.json");
+	const turbo = JSON.parse(await readFile(turboPath, "utf8"));
+	turbo.globalDependencies = turbo.globalDependencies.filter(
+		(entry) => entry !== ".agents/skills/openapi-to-setup/**",
+	);
+	await writeFile(turboPath, `${JSON.stringify(turbo, null, 2)}\n`);
+	assertFailure(
+		{ failures: await auditCodexSkillInstallerContracts(root) },
+		/Turbo globalDependencies must invalidate consumer Skill assets/,
+	);
 });
 
 test("consumer acceptance contract accepts the consolidated packed path", async (t) => {

--- a/scripts/repository-contract.node-test.mjs
+++ b/scripts/repository-contract.node-test.mjs
@@ -525,6 +525,124 @@ test("Codex Skill installer distribution, CLI, packed smoke, and docs stay align
 	);
 });
 
+test("aggregate aliases disable notifier only for the real skills top-level command", async (t) => {
+	const root = await mkdtemp(
+		join(tmpdir(), "openapi-to-aggregate-skills-wrapper-"),
+	);
+	t.after(() => rm(root, { recursive: true, force: true }));
+	const wrapper = await readFile(
+		join(repositoryRoot, "packages/openapi/bin/openapi.js"),
+		"utf8",
+	);
+	for (const relativePath of [
+		"packages/openapi/bin/openapi.js",
+		"packages/openapi/bin/openapi-to.js",
+	]) {
+		await writeFixtureFile(root, relativePath, wrapper);
+	}
+	await writeFixtureFile(
+		root,
+		"package.json",
+		'{"private":true,"type":"module"}\n',
+	);
+	await writeFixtureFile(
+		root,
+		"node_modules/semver/package.json",
+		'{"name":"semver","type":"module","exports":"./index.js"}\n',
+	);
+	await writeFixtureFile(
+		root,
+		"node_modules/semver/index.js",
+		"export default { satisfies: () => true };\n",
+	);
+	await writeFixtureFile(
+		root,
+		"node_modules/@openapi-to/cli/package.json",
+		'{"name":"@openapi-to/cli","type":"module","exports":"./index.js"}\n',
+	);
+	await writeFixtureFile(
+		root,
+		"node_modules/@openapi-to/cli/index.js",
+		`import { appendFile } from "node:fs/promises";
+export async function run(argv) {
+  await appendFile(process.env.OPENAPI_TO_RUN_TRACE, JSON.stringify(argv.slice(2)) + "\\n");
+}
+`,
+	);
+	await writeFixtureFile(
+		root,
+		"packages/openapi/dist/utils.js",
+		`import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+export function updateVersionNotifier() {
+  appendFileSync(process.env.OPENAPI_TO_NOTIFIER_TRACE, "called\\n");
+  mkdirSync(process.env.OPENAPI_TO_NOTIFIER_STATE, { recursive: true });
+  writeFileSync(process.env.OPENAPI_TO_NOTIFIER_STATE + "/state", "created\\n");
+}
+`,
+	);
+	const notifierTrace = join(root, "notifier-calls");
+	const notifierState = join(root, "notifier-state");
+	const runTrace = join(root, "run-calls");
+	const runAlias = async (alias, args) => {
+		await rm(notifierTrace, { force: true });
+		await rm(notifierState, { recursive: true, force: true });
+		await rm(runTrace, { force: true });
+		await execFileAsync(
+			process.execPath,
+			[join(root, "packages/openapi/bin", `${alias}.js`), ...args],
+			{
+				cwd: root,
+				env: {
+					...process.env,
+					OPENAPI_TO_NOTIFIER_TRACE: notifierTrace,
+					OPENAPI_TO_NOTIFIER_STATE: notifierState,
+					OPENAPI_TO_RUN_TRACE: runTrace,
+				},
+			},
+		);
+		assert.deepEqual(
+			JSON.parse((await readFile(runTrace, "utf8")).trim()),
+			args,
+		);
+	};
+	const skillsCases = [
+		["skills", "install", "--host", "codex"],
+		["--debug", "skills", "install", "--host", "codex"],
+		["--json", "skills", "install", "--host", "codex"],
+		["--debug", "--json", "skills", "install", "--host", "codex"],
+		["--json", "--debug", "skills", "unsupported"],
+		["--debug=true", "skills", "install", "--host", "codex"],
+		["--json=true", "skills", "install", "--host", "codex"],
+		["--debug=false", "skills", "install", "--host", "codex"],
+		["--json=false", "skills", "install", "--host", "codex"],
+		["--no-debug", "skills", "install", "--host", "codex"],
+		["--no-json", "skills", "install", "--host", "codex"],
+		["skills", "install", "--host", "codex", "--debug"],
+	];
+	for (const alias of ["openapi", "openapi-to"]) {
+		for (const args of skillsCases) {
+			await runAlias(alias, args);
+			await assert.rejects(readFile(notifierTrace), { code: "ENOENT" });
+			await assert.rejects(readFile(join(notifierState, "state")), {
+				code: "ENOENT",
+			});
+		}
+	}
+	for (const args of [
+		["inspect", "./skills"],
+		["validate", "skills"],
+		["diff", "old-skills.yaml", "new-skills.yaml"],
+		["generate", "--config", "./skills/openapi.config.ts"],
+	]) {
+		await runAlias("openapi", args);
+		assert.equal(await readFile(notifierTrace, "utf8"), "called\n");
+		assert.equal(
+			await readFile(join(notifierState, "state"), "utf8"),
+			"created\n",
+		);
+	}
+});
+
 test("consumer acceptance contract accepts the consolidated packed path", async (t) => {
 	const root = await createConsumerAcceptanceContractFixture(t);
 	assert.deepEqual(await auditConsumerAcceptanceContracts(root), []);

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,10 @@
 {
 	"$schema": "https://turbo.build/schema.json",
+	"globalDependencies": [
+		".agents/skills/openapi-to-generate/**",
+		".agents/skills/openapi-to-setup/**",
+		"scripts/build-consumer-skill-assets.mjs"
+	],
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

This completes the versioned Codex Skill installer MVP and closes both confirmed Phase 1.1 review blockers.

- Ships the two packaged, versioned consumer Skills through both aggregate CLI aliases.
- Fixes P1-A by identifying the real top-level `skills` command after supported global boolean options, so `--debug` / `--json` (including `--no-*` and equality forms) do not run the update notifier. Ordinary command arguments or paths containing `skills` are not misclassified.
- Fixes P1-B with a persisted transaction journal, ownership record, marker, and device/inode binding. Normal cleanup and interrupted recovery share the same verifier, atomically quarantine verified staging, and use manifest-scoped unlink plus non-recursive rmdir instead of path-based recursive staging deletion. Unprovable ownership fails closed with `SKILLS_INSTALL_RECOVERY_REQUIRED` and preserves evidence.

## Mutation and regression coverage

- Proved the wrapper regression by temporarily restoring fixed-position command detection and observing the notifier-state test fail.
- Proved ownership enforcement by removing staging verification and observing replacement protection fail.
- Proved the final race protection by removing the per-step persisted root-identity guard and observing both post-quarantine replacement tests delete the cloned `SKILL.md` and fail.
- Covers both aliases, supported global option placements, false-positive argument/path cases, notifier state, network attempts, normal/recovery replacement windows, missing or corrupt ownership evidence, symlinks, extra entries, and successful cleanup.

## Changeset

The existing task changeset `.changeset/curly-bottles-prove.md` remains the release metadata for this MVP. No duplicate changeset was added.

## Local validation

- `pnpm --filter @openapi-to/cli typecheck`
- installer suite: 36/36
- full CLI suite: 49/49
- repository contract and cross-platform installer smoke
- fresh-tarball `pnpm release:smoke` (`networkAttempted: false`)
- release scripts: 189/189
- `pnpm lint:ci` and changed-file lint
- `pnpm changeset status`
- `pnpm verify:precommit`: 694 passed, 2 platform skips
- `git diff --check`
- independent local review: P0 none, P1 none, P2 none

## Security boundaries

OpenAPI and packaged assets remain untrusted input. The installer performs no Skill-path network access, never overwrites an existing destination, never follows staging ownership symlinks, bounds and validates persisted records, and preserves ambiguous transaction evidence for manual recovery. This PR does not merge, publish, tag, release, or change repository settings.